### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,3 +3,6 @@
 run:
   go: '1.17'
   timeout: 5m
+
+  # Timeout for analysis, Default: 1m
+  timeout: 5m


### PR DESCRIPTION
1 min is too low, the lint github action can fail with timeout