### PR TITLE
Fields API to return "(null)" values

### DIFF
--- a/API.md
+++ b/API.md
@@ -55,14 +55,14 @@ Example of queries:
 //return resources with the tag "team" defined
 {
   "filter":{
-	  "team": "[not null]"
+	  "team": "(not null)"
   }
 }
 
 //return resources missing the tag "team"
 {
   "filter":{
-	  "team": "[null]"
+	  "team": "(null)"
   }
 }
 

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -159,7 +159,7 @@ func TestSearchByQuery(t *testing.T) {
 			//test exclude - returns the resources without the tag release
 			query = `{
   "filter":{
-    "release": "[null]"
+    "release": "(null)"
   }
 }`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
@@ -170,8 +170,8 @@ func TestSearchByQuery(t *testing.T) {
 			//test 2 exclusions - the s3 bucket is the only one without both tags
 			query = `{
   "filter":{
-    "release": "[null]",
-    "debug:info": "[null]"
+    "release": "(null)",
+    "debug:info": "(null)"
   }
 }`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
@@ -181,7 +181,7 @@ func TestSearchByQuery(t *testing.T) {
 			//mix include and exclude filters
 			query = `{
   "filter":{
-    "release":"[not null]",
+    "release":"(not null)",
     "vpc":"vpc-123"
   }
 }`
@@ -285,6 +285,7 @@ func TestFields(t *testing.T) {
 				Values: model.FieldValues{
 					model.FieldValue{Value: "infra", Count: 1},
 					model.FieldValue{Value: "dev", Count: 1},
+					model.FieldValue{Value: "(null)", Count: 1},
 				}}, *fields.FindField("tags", "team"))
 
 			//test long field
@@ -293,6 +294,7 @@ func TestFields(t *testing.T) {
 				Count: 1,
 				Values: model.FieldValues{
 					model.FieldValue{Value: tagMaxValue, Count: 1},
+					model.FieldValue{Value: "(null)", Count: 2},
 				}}, *fields.FindField("tags", tagMaxKey))
 
 			//test the tag field called "region"
@@ -301,6 +303,7 @@ func TestFields(t *testing.T) {
 				Count: 1,
 				Values: model.FieldValues{
 					model.FieldValue{Value: "us-west-2", Count: 1},
+					model.FieldValue{Value: "(null)", Count: 2},
 				}}, *fields.FindField("tags", "region"))
 
 		})

--- a/pkg/datastore/resourceindexer.go
+++ b/pkg/datastore/resourceindexer.go
@@ -322,11 +322,11 @@ func (ri *resourceIndexer) parse(jsonQuery []byte) (*rql.Params, error) {
 func replaceNullValues(p *rql.Params) *rql.Params {
 	for i, arg := range p.FilterArgs {
 		if s, ok := arg.(string); ok {
-			if s == "[null]" {
+			if s == model.NullValue {
 				p.FilterExp = replaceWith(p.FilterExp, "=", "is", "?", i)
 				p.FilterArgs[i] = nil
 			}
-			if s == "[not null]" {
+			if s == model.NotNullValue {
 				p.FilterExp = replaceWith(p.FilterExp, "=", "is not", "?", i)
 				p.FilterArgs[i] = nil
 			}

--- a/pkg/datastore/resourceindexer_test.go
+++ b/pkg/datastore/resourceindexer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/a8m/rql"
+	"github.com/run-x/cloudgrep/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zaptest"
 )
@@ -116,25 +117,25 @@ func TestReplaceNullValues(t *testing.T) {
 	}{
 		{
 			"col_17 = ? AND region = ? AND type = ?",
-			[]interface{}{"[null]", "us-east-1", "ec2.instance"},
+			[]interface{}{model.NullValue, "us-east-1", "ec2.instance"},
 			"col_17 is ? AND region = ? AND type = ?",
 			[]interface{}{nil, "us-east-1", "ec2.instance"},
 		},
 		{
 			"col_17 = ? AND region = ? AND type = ?",
-			[]interface{}{"[null]", "us-east-1", "[null]"},
+			[]interface{}{model.NullValue, "us-east-1", model.NullValue},
 			"col_17 is ? AND region = ? AND type is ?",
 			[]interface{}{nil, "us-east-1", nil},
 		},
 		{
 			"(col_17 = ? OR col_17 = ?) AND type = ?",
-			[]interface{}{"[null]", "[null]", "[null]"},
+			[]interface{}{model.NullValue, model.NullValue, model.NullValue},
 			"(col_17 is ? OR col_17 is ?) AND type is ?",
 			[]interface{}{nil, nil, nil},
 		},
 		{
 			"(col_17 = ? OR col_17 = ?) AND type = ?",
-			[]interface{}{"[null]", "[not null]", "[null]"},
+			[]interface{}{model.NullValue, model.NotNullValue, model.NullValue},
 			"(col_17 is ? OR col_17 is not ?) AND type is ?",
 			[]interface{}{nil, nil, nil},
 		},

--- a/pkg/datastore/sqlitestore.go
+++ b/pkg/datastore/sqlitestore.go
@@ -264,7 +264,7 @@ func (s *SQLiteStore) GetFields(context.Context) (model.FieldGroups, error) {
 	}
 	fieldGroups = append(fieldGroups, tagsGroup)
 
-	return fieldGroups, nil
+	return fieldGroups.AddNullValues(), nil
 }
 
 func (s *SQLiteStore) GetResources(ctx context.Context, jsonQuery []byte) ([]*model.Resource, error) {

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -1,17 +1,28 @@
 package model
 
+//NullValue used in a query, means that the resource should not have this field defined
+const NullValue = "(null)"
+
+//NullValue used in a query, means that the resource should have this field defined
+const NotNullValue = "(not null)"
+
+//FieldGroup regroups some fields. Ex: "Tags"
 type FieldGroup struct {
 	Name   string `json:"name"`
 	Fields Fields `json:"fields"`
 }
 type FieldGroups []FieldGroup
 
+//Field is a searchable attribute on a resource.
+//It also includes the possible values and their respective count.
 type Field struct {
 	Name   string      `json:"name"`
 	Count  int         `json:"count"`
 	Values FieldValues `json:"values"`
 }
 
+//FieldValue is a value associated with a field.
+//The count is the number of resources with this field value.
 type FieldValue struct {
 	Value string `json:"value"`
 	Count int    `json:"count"`
@@ -39,4 +50,37 @@ func (fgs FieldGroups) FindField(group string, name string) *Field {
 		}
 	}
 	return nil
+}
+
+//count returns the number of resources
+func (fgs FieldGroups) count() int {
+	//assuming each resource always has type set
+	if field := fgs.FindField("core", "type"); field != nil {
+		return field.Count
+	}
+	return 0
+}
+
+//AddNullValues adds the (null) value for each Field, it is used by the API to allow filtering on resources without the field.
+//If a field is always defined (ex: type), do not include the (null) value as it would mean excluding all resources from a query.
+func (fgs FieldGroups) AddNullValues() FieldGroups {
+	var result []FieldGroup
+	totalCount := fgs.count()
+	for _, group := range fgs {
+		var fields Fields
+		for _, field := range group.Fields {
+			nullCount := totalCount - field.Count
+			//do not show null if all resource would be excluded
+			if nullCount > 0 {
+				field.Values = append(field.Values,
+					FieldValue{
+						Value: NullValue,
+						Count: nullCount,
+					})
+			}
+			fields = append(fields, field)
+		}
+		result = append(result, FieldGroup{Name: group.Name, Fields: fields})
+	}
+	return result
 }

--- a/pkg/model/fields_test.go
+++ b/pkg/model/fields_test.go
@@ -24,3 +24,64 @@ func TestFieldFind(t *testing.T) {
 	assert.Equal(t, "core", groups.FindGroup("core").Name)
 	AssertEqualsField(t, f2, *groups.FindField("core", "type"))
 }
+
+func TestFieldsAddNullValues(t *testing.T) {
+	groups := FieldGroups{
+		{
+			Name: "core",
+			Fields: []Field{{
+				Name:  "region",
+				Count: 3,
+				Values: []FieldValue{
+					{Value: "us-east-1", Count: 2},
+					{Value: "us-west-2", Count: 1},
+				},
+			}, {
+				Name:  "type",
+				Count: 3,
+				Values: []FieldValue{
+					{Value: "ec2.instance", Count: 3},
+				},
+			}, {
+				Name:  "cluster",
+				Count: 2,
+				Values: []FieldValue{
+					{Value: "dev", Count: 2},
+				},
+			},
+			},
+		},
+	}
+	groupsNullable := groups.AddNullValues()
+	assert.Equal(t, FieldGroups{
+		{
+			Name: "core",
+			Fields: []Field{{
+				Name:  "region",
+				Count: 3,
+				Values: []FieldValue{
+					{Value: "us-east-1", Count: 2},
+					{Value: "us-west-2", Count: 1},
+					//do not show (null) if all resources have this field
+				},
+			}, {
+				Name:  "type",
+				Count: 3,
+				Values: []FieldValue{
+					{Value: "ec2.instance", Count: 3},
+				},
+			}, {
+				Name:  "cluster",
+				Count: 2,
+				Values: []FieldValue{
+					{Value: "dev", Count: 2},
+					//(null) count is the count of resources without this field
+					{Value: "(null)", Count: 1},
+				},
+			},
+			},
+		},
+	}, groupsNullable)
+
+	// groups.
+}


### PR DESCRIPTION
- Return "(null)" values for each field
- If a field is always present, do not include the "(null)" value. It would mean excluding all resources.