### PR TITLE
Always run CI checks in PRs even if not targetting main branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 env:
   GO_VERSION: 1.18

--- a/.github/workflows/integration-setup.yml
+++ b/.github/workflows/integration-setup.yml
@@ -21,8 +21,6 @@ on:
 
   pull_request:
     types: [opened, synchronize]
-    branches:
-      - main
     paths:
       - "integration/aws/terraform/**"
 


### PR DESCRIPTION
There isn't a special need to avoid these checks if the PR is targeting a non-main branch.