### PR TITLE
Add ability to skip database refresh on startup

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,9 @@ their cloud accounts.`,
 	flags.Bool("skip-open", defaultConfig.Web.SkipOpen, "Skip running the open command to open default browser")
 	_ = viper.BindPFlag("web.skipOpen", flags.Lookup("skip-open"))
 
+	flags.Bool("skip-refresh", defaultConfig.Datastore.SkipRefresh, "Skip running data refresh on start up")
+	_ = viper.BindPFlag("datastore.skipRefresh", flags.Lookup("skip-refresh"))
+
 	rootCmd.AddCommand(NewVersionCommand(out))
 
 	return rootCmd

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -40,8 +40,10 @@ func Run(ctx context.Context, cfg config.Config, logger *zap.Logger) error {
 	}
 
 	//start the providers to collect cloud data
-	if err := cli.runEngine(ctx); err != nil {
-		return err
+	if !cfg.Datastore.SkipRefresh {
+		if err := cli.runEngine(ctx); err != nil {
+			return err
+		}
 	}
 	api.StartWebServer(ctx, cfg, logger, cli.ds, cli.runEngine)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type Provider struct {
 
 type Datastore struct {
 	Type           string `yaml:"type"`
+	SkipRefresh    bool   `yaml:"skipRefresh"`
 	DataSourceName string `yaml:"dataSourceName"`
 }
 

--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -7,6 +7,7 @@ web:
   skipOpen: false
 
 datastore:
+  skipRefresh: false
   type: sqlite
   # TODO once we support updating existing resources switch to disk
   dataSourceName: "file::memory:?cache=shared"


### PR DESCRIPTION
Cause now folks can store the db to a file.
Can be done via a `--skip-refresh` cli flag or specifying it on the yaml as per the change in the config.yaml