### PR TITLE
Run the race detector in more places

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,4 +125,4 @@ clean:
 	@rm -rf ./bin/*
 
 awsgen:
-	go run -race ./hack/awsgen --config pkg/provider/aws/config/config.yaml --output-dir pkg/provider/aws
+	CGO_ENABLED=1 go run -race ./hack/awsgen --config pkg/provider/aws/config/config.yaml --output-dir pkg/provider/aws


### PR DESCRIPTION
When building cloudgrep (except for releases), enable the race detector. Currently, we are only running it during tests, which has the potential to miss data races. Since the race detector slows code down significantly, don't enable it during load tests or when building for release.