### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,5 @@
 
 # Don't count generated files in stats, and hide their diffs
 zz_*.go linguist-generated
-/static linguist-generated
+/static/** linguist-generated
 go.sum linguist-generated


### PR DESCRIPTION
- Makes diffs for go code nicer
- Marks generated files to reduce PR diff size and remove generated code from stats