### PR TITLE
Increase open connection limit

### DIFF
--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -14,8 +16,8 @@ import (
 	"github.com/run-x/cloudgrep/pkg/provider/types"
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 	"github.com/run-x/cloudgrep/pkg/util"
+	_ "github.com/run-x/cloudgrep/pkg/util/rlimit"
 	"go.uber.org/zap"
-	"os"
 )
 
 type Provider struct {

--- a/pkg/util/rlimit/LICENSE
+++ b/pkg/util/rlimit/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkg/util/rlimit/doc.go
+++ b/pkg/util/rlimit/doc.go
@@ -1,0 +1,3 @@
+// Backport of os/rlimit.go from go1.19.
+// Raises open file descriptor limit at init.
+package rlimit

--- a/pkg/util/rlimit/rlimit.go
+++ b/pkg/util/rlimit/rlimit.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.19 && (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+
+package rlimit
+
+import "syscall"
+
+// Some systems set an artificially low soft limit on open file count, for compatibility
+// with code that uses select and its hard-coded maximum file descriptor
+// (limited by the size of fd_set).
+//
+// Go does not use select, so it should not be subject to these limits.
+// On some systems the limit is 256, which is very easy to run into,
+// even in simple programs like gofmt when they parallelize walking
+// a file tree.
+//
+// After a long discussion on go.dev/issue/46279, we decided the
+// best approach was for Go to raise the limit unconditionally for itself,
+// and then leave old software to set the limit back as needed.
+// Code that really wants Go to leave the limit alone can set the hard limit,
+// which Go of course has no choice but to respect.
+func init() {
+	var lim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim); err == nil && lim.Cur != lim.Max {
+		lim.Cur = lim.Max
+		adjustFileLimit(&lim)
+		_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &lim)
+	}
+}

--- a/pkg/util/rlimit/rlimit_darwin.go
+++ b/pkg/util/rlimit/rlimit_darwin.go
@@ -1,0 +1,22 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build darwin
+
+package rlimit
+
+import "syscall"
+
+// adjustFileLimit adds per-OS limitations on the Rlimit used for RLIMIT_NOFILE. See rlimit.go.
+func adjustFileLimit(lim *syscall.Rlimit) {
+	// On older macOS, setrlimit(RLIMIT_NOFILE, lim) with lim.Cur = infinity fails.
+	// Set to the value of kern.maxfilesperproc instead.
+	n, err := syscall.SysctlUint32("kern.maxfilesperproc")
+	if err != nil {
+		return
+	}
+	if lim.Cur > uint64(n) {
+		lim.Cur = uint64(n)
+	}
+}

--- a/pkg/util/rlimit/rlimit_go19.go
+++ b/pkg/util/rlimit/rlimit_go19.go
@@ -1,0 +1,6 @@
+//go:build go1.19
+
+package rlimit
+
+// This fix is implemented in go1.19
+import _ "os"

--- a/pkg/util/rlimit/rlimit_stub.go
+++ b/pkg/util/rlimit/rlimit_stub.go
@@ -1,0 +1,12 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package rlimit
+
+import "syscall"
+
+// adjustFileLimit adds per-OS limitations on the Rlimit used for RLIMIT_NOFILE. See rlimit.go.
+func adjustFileLimit(lim *syscall.Rlimit) {}

--- a/pkg/util/rlimit/rlimit_test.go
+++ b/pkg/util/rlimit/rlimit_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.19
+
+package rlimit_test
+
+import (
+	. "os"
+	"runtime"
+	"testing"
+)
+
+func TestOpenFileLimit(t *testing.T) {
+	// For open file count,
+	// macOS sets the default soft limit to 256 and no hard limit.
+	// CentOS and Fedora set the default soft limit to 1024,
+	// with hard limits of 4096 and 524288, respectively.
+	// Check that we can open 1200 files, which proves
+	// that the rlimit is being raised appropriately on those systems.
+	fileCount := 1200
+
+	// OpenBSD has a default soft limit of 512 and hard limit of 1024.
+	if runtime.GOOS == "openbsd" {
+		fileCount = 768
+	}
+
+	var files []*File
+	for i := 0; i < fileCount; i++ {
+		f, err := Open("rlimit.go")
+		if err != nil {
+			t.Error(err)
+			break
+		}
+		files = append(files, f)
+	}
+
+	for _, f := range files {
+		f.Close()
+	}
+}


### PR DESCRIPTION
This is a backport of a fix present in Go 1.19 (currently in beta) that increases the soft limit for file descriptors on unix systems. We run into this limit because we try to fetch all the resources in each configured region all at once. Usually, this results in a confusing DNS error mentioning the AWS API endpoint hostnames couldn't be resolved.