### PR TITLE
update api test to use `/resources` to get fields

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -171,6 +171,24 @@ func TestResourcesPostRoute(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 		require.Equal(t, 2, response.Count)
 		testingutil.AssertEqualsResources(t, model.Resources{resourceInst1, resourceInst2}, response.Resources)
+
+		//check a few fields
+		fields := response.FieldGroups
+		testingutil.AssertEqualsField(t, model.Field{
+			Name:  "team",
+			Count: 2,
+			Values: model.FieldValues{
+				&model.FieldValue{Value: "infra", Count: "1"},
+				&model.FieldValue{Value: "dev", Count: "1"},
+			}}, *fields.FindField("tags", "team"))
+		testingutil.AssertEqualsField(t, model.Field{
+			Name:  "type",
+			Count: 2,
+			Values: model.FieldValues{
+				&model.FieldValue{Value: "test.Instance", Count: "2"},
+				&model.FieldValue{Value: "s3.Bucket", Count: "-"},
+			}}, *fields.FindField("core", "type"))
+
 	})
 
 	t.Run("FilterEmpty", func(t *testing.T) {
@@ -270,12 +288,12 @@ func TestResourceRoute(t *testing.T) {
 	})
 }
 
-func TestFieldsRoute(t *testing.T) {
+func TestResourceFieldsRoute(t *testing.T) {
 	m := prepareApiUnitTest(t)
-	path := "/api/fields"
+	path := "/api/resources"
 
 	t.Run("Standard", func(t *testing.T) {
-		var response model.FieldGroups
+		var response model.ResourcesResponse
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", path, nil)
 		require.NoError(t, err)
@@ -283,12 +301,13 @@ func TestFieldsRoute(t *testing.T) {
 		require.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 		require.Equal(t, http.StatusOK, w.Code)
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-		require.Equal(t, len(response), 2)
+		fields := response.FieldGroups
+		require.Equal(t, len(fields), 2)
 		//check number of groups
-		require.Equal(t, 2, len(response))
+		require.Equal(t, 2, len(fields))
 		//check fields by group
-		require.Equal(t, 2, len(response.FindGroup("core").Fields))
-		require.Equal(t, 10, len(response.FindGroup("tags").Fields))
+		require.Equal(t, 2, len(fields.FindGroup("core").Fields))
+		require.Equal(t, 10, len(fields.FindGroup("tags").Fields))
 	})
 }
 


### PR DESCRIPTION
`/api/fields` is deprecated so tests need to be updated.