### PR TITLE
handle duplicate resource id error in datastore

### DIFF
--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -512,6 +512,13 @@ func TestUpdateResources(t *testing.T) {
 			//searching on deleting tag returns nothing
 			testQueryNoResult(t, ctx, ds, deletedTag.Key, deletedTag.Value)
 
+			//send 2 resources with same id
+			r1DuplicateId, err := ds.GetResource(ctx, resources[1].Id)
+			require.NoError(t, err)
+			r1DuplicateId.Id = r1.Id
+			//only 1 resource would be written without throwing an error
+			require.NoError(t, ds.WriteResources(ctx, model.Resources{r1, r1DuplicateId}))
+
 		})
 	}
 }


### PR DESCRIPTION
Main branch behavior:

{"level":"error","ts":1656088510.564648,"caller":"sequencer/async.go:85","msg":"Received an error when trying to write resources to data store can't write resources to database: could not create the resource indexes: UNIQUE constraint failed: resource_index.id","stacktrace":"github.com/run-x/cloudgrep/pkg/sequencer.AsyncSequencer.readResourceChan\n\t/Users/runner/work/cloudgrep/cloudgrep/pkg/sequencer/async.go:85"}


With this fix:

{"level":"warn","ts":1656093409.715523,"caller":"datastore/resourceindexer.go:328","msg":"Found duplicate key","key":"eks-6ebeb886-f5f4-aade-44f3-b473c88ab09f","resource 1":{"id":"eks-6ebeb886-f5f4-aade-44f3-b473c88ab09f","region":"us-east-1","type":"autoscaling.AutoScalingGroup"},"resource 2":{"id":"eks-6ebeb886-f5f4-aade-44f3-b473c88ab09f","region":"global","type":"iam.InstanceProfile"}}
