### PR TITLE
use arn as id for IAM resources

### DIFF
--- a/pkg/provider/aws/iam.go
+++ b/pkg/provider/aws/iam.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/run-x/cloudgrep/pkg/model"
@@ -13,19 +14,19 @@ func (p *Provider) register_iam_manual(mapping map[string]mapper) {
 	mapping["iam.User"] = mapper{
 		ServiceEndpointID: "iam",
 		FetchFunc:         p.fetch_iam_User,
-		IdField:           "UserId",
+		IdField:           "Arn",
 		IsGlobal:          true,
 	}
 	mapping["iam.InstanceProfile"] = mapper{
 		ServiceEndpointID: "iam",
 		FetchFunc:         p.fetch_iam_InstanceProfile,
-		IdField:           "InstanceProfileId",
+		IdField:           "Arn",
 		IsGlobal:          true,
 	}
 	mapping["iam.Role"] = mapper{
 		ServiceEndpointID: "iam",
 		FetchFunc:         p.fetch_iam_Role,
-		IdField:           "RoleId",
+		IdField:           "Arn",
 		IsGlobal:          true,
 	}
 }


### PR DESCRIPTION
These are more meaningful since they contain the name.
The role/user/instanceProfile id are just generated strings.

<img width="730" alt="Screen Shot 2022-06-24 at 11 49 49 AM" src="https://user-images.githubusercontent.com/9467584/175647313-340948b4-b3b1-41a2-a780-b7310caacbe4.png">
<img width="766" alt="Screen Shot 2022-06-24 at 11 48 52 AM" src="https://user-images.githubusercontent.com/9467584/175647316-8be7d0be-80d2-416f-8e4b-55bf00f64b8b.png">
<img width="364" alt="Screen Shot 2022-06-24 at 11 48 36 AM" src="https://user-images.githubusercontent.com/9467584/175647320-f4018d70-d359-4ff0-9d2e-e1c6a34fad8a.png">
