### PR TITLE
configure codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+
+
+# any PR needs approval from run-x dev team
+*       @run-x/dev @eljevakovic


### PR DESCRIPTION
Approvals from run-x team members will be required to merge a PR. (except for admin)