### PR TITLE
Fix could not create the resource indexes: too many SQL variables

### DIFF
--- a/loadtest/datastore/datastore_load_test.go
+++ b/loadtest/datastore/datastore_load_test.go
@@ -67,6 +67,13 @@ func TestLoad(t *testing.T) {
 			BatchSize: 100,
 			Queries:   200,
 		},
+		//simulate a large batch
+		{
+			Resources: 1200,
+			Tags:      50,
+			BatchSize: 1200,
+			Queries:   1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/loadtest/datastore/datastore_load_test.go
+++ b/loadtest/datastore/datastore_load_test.go
@@ -59,7 +59,7 @@ func TestLoad(t *testing.T) {
 			BatchSize: 1,
 			Queries:   1,
 		},
-		//this is the load test
+		//this is the primary load test
 		{
 			Resources: 2000,
 			//total includes the mandatory fields (region, type) and should be under 2000

--- a/pkg/datastore/sqlitestore.go
+++ b/pkg/datastore/sqlitestore.go
@@ -141,7 +141,7 @@ func (s *SQLiteStore) WriteResources(ctx context.Context, resources model.Resour
 				return err
 			}
 
-			// Create or Update all rows
+			// Create or Update the resource rows
 			result := tx.Clauses(clause.OnConflict{UpdateAll: true}).Create(batch)
 			s.logger.Sugar().Infow("Writting resources: ", zap.Int64("count", result.RowsAffected))
 

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -59,8 +59,12 @@ func (rs Resources) FindById(id string) *Resource {
 }
 
 func (rs Resources) Ids() []ResourceId {
-	ids := make([]ResourceId, len(rs))
-	for i, r := range rs {
+	return ResourceIds(rs)
+}
+
+func ResourceIds(resources []*Resource) []ResourceId {
+	ids := make([]ResourceId, len(resources))
+	for i, r := range resources {
 		ids[i] = ResourceId(r.Id)
 	}
 	return ids

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -1,0 +1,19 @@
+package util
+
+func Chunks[T any](xs []T, chunkSize int) [][]T {
+	divided := make([][]T, (len(xs)+chunkSize-1)/chunkSize)
+	if len(xs) == 0 {
+		return divided
+	}
+	prev := 0
+	i := 0
+	till := len(xs) - chunkSize
+	for prev < till {
+		next := prev + chunkSize
+		divided[i] = xs[prev:next]
+		prev = next
+		i++
+	}
+	divided[i] = xs[prev:]
+	return divided
+}

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunks(t *testing.T) {
+	testCases := []struct {
+		input     []string
+		chunkSize int
+		output    [][]string
+	}{
+		{[]string{}, 3, [][]string{}},
+		{[]string{"1", "2", "3", "4", "5", "6"}, 3, [][]string{{"1", "2", "3"}, {"4", "5", "6"}}},
+		{[]string{"1", "2", "3", "4", "5", "6"}, 9, [][]string{{"1", "2", "3", "4", "5", "6"}}},
+		{[]string{"1", "2", "3", "4", "5", "6"}, 6, [][]string{{"1", "2", "3", "4", "5", "6"}}},
+		{[]string{"1", "2", "3", "4", "5", "6"}, 5, [][]string{{"1", "2", "3", "4", "5"}, {"6"}}},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.output, Chunks(tc.input, tc.chunkSize))
+	}
+}


### PR DESCRIPTION
- Batch the resources before writing them to the DB.
For large AWS accounts, we can get >1,000 resources at once, and it would generate a SQL statement over the limit of one million bytes in length. https://www.sqlite.org/limits.html

- Add a load test to test 1,200 resources added at once.