### PR TITLE
add core/tags prefix in query fields

### DIFF
--- a/API.md
+++ b/API.md
@@ -503,7 +503,6 @@ Sample Responses:
     }
 ]
 }
-
 ```
 
 If you need to know when the engine is done running, keep pulling this endpoint until the status is no longer **fetching**.

--- a/API.md
+++ b/API.md
@@ -22,11 +22,11 @@ To filter the resources, send a body containing a query.
   "offset": 0,
   //filter the resources
   "filter": {
-    "type": "ec2.Instance"
-    "env": "prod"
+    "core.type": "ec2.Instance"
+    "tags.env": "prod"
   }
   //optional sort
-  "sort": ["type"]
+  "sort": ["core.type"]
 }
 ```
 
@@ -53,10 +53,10 @@ The response contains:
   "offset": 0,
   //filter the resources
   "filter": {
-    "type": "ec2.Instance"
+    "core.type": "ec2.Instance"
   }
   //optional sort
-  "sort": ["type"]
+  "sort": ["core.type"]
 }
 ```
 
@@ -65,7 +65,7 @@ curl --location --request POST 'http://localhost:8080/api/resources' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "filter": {
-        "kubernetes.io/created-for/pv/name": "opta-persistent-0-hellopv-hellopv-k8s-service-0"
+        "tags.kubernetes.io/created-for/pv/name": "opta-persistent-0-hellopv-hellopv-k8s-service-0"
     }
 }'
 ```
@@ -79,22 +79,22 @@ Example of queries:
 //return resources of type "ec2.Instance" with the tag "team" equals "marketplace"
 {
   "filter":{
-    "type": "ec2.Instance",
-	  "team": "marketplace"
+    "core.type": "ec2.Instance",
+	  "tags.team": "marketplace"
   }
 }
 
 //return resources with the tag "team" defined
 {
   "filter":{
-	  "team": "(not null)"
+	  "tags.team": "(not null)"
   }
 }
 
 //return resources missing the tag "team"
 {
   "filter":{
-	  "team": "(missing)"
+	  "tags.team": "(missing)"
   }
 }
 
@@ -102,10 +102,10 @@ Example of queries:
 // will return resources with type=ec2.Volume AND (team="marketplace" OR team="shipping")
 {
   "filter":{
-    "type":"ec2.Volume",
+    "core.type":"ec2.Volume",
     "$or": [
-      { "team": "marketplace" },
-      { "team": "shipping" }
+      { "tags.team": "marketplace" },
+      { "tags.team": "shipping" }
     ]
   } 
 }
@@ -115,17 +115,17 @@ Example of queries:
 {
   "filter":{
     "$or": [
-      { "team": "marketplace" },
-      { "team": "shipping" }
+      { "tags.team": "marketplace" },
+      { "tags.team": "shipping" }
     ],
     "$and": [
       { "$or": [
-        { "cluster": "dev" },
-        { "cluster": "prod" }
+        { "tags.cluster": "dev" },
+        { "tags.cluster": "prod" }
       ] },
       { "$or": [
-        { "size": "large" },
-        { "size": "medium" }
+        { "tags.size": "large" },
+        { "tags.size": "medium" }
       ] }
     ]
   }
@@ -134,18 +134,18 @@ Example of queries:
 //sort by a field
 {
   "filter":{
-    "type": "s3.Bucket"
+    "core.type": "s3.Bucket"
   },
-  "sort": ["region"]
+  "sort": ["core.region"]
 }
 
 //The default order for column is ascending order but you can control it with an optional prefix: + or -. + means ascending order, and - means descending order.
 //sort by region desc
 {
   "filter":{
-    "type": "s3.Bucket"
+    "core.type": "s3.Bucket"
   },
-  "sort": ["-region"]
+  "sort": ["-core.region"]
 }
 
 //Set a limit: default 25, Max is 100
@@ -153,7 +153,7 @@ Example of queries:
 {
   "limit": 10,
   "filter":{
-    "type": "ec2.Instance"
+    "core.type": "ec2.Instance"
   }
 }
 
@@ -163,7 +163,7 @@ Example of queries:
   "limit": 10,
   "offset": 0,
   "filter":{
-    "type": "ec2.Instance"
+    "core.type": "ec2.Instance"
   }
 }
 //second page: next 10 results
@@ -171,7 +171,7 @@ Example of queries:
   "limit": 10,
   "offset": 10,
   "filter":{
-    "type": "ec2.Instance"
+    "core.type": "ec2.Instance"
   }
 }
 

--- a/loadtest/datastore/datastore_load_test.go
+++ b/loadtest/datastore/datastore_load_test.go
@@ -159,10 +159,11 @@ func TestLoad(t *testing.T) {
 					//add some fields
 					filter := make(map[string]interface{})
 					for t, tag := range randResource.Tags {
-						filter[tag.Key] = tag.Value
+						fieldName := fmt.Sprintf("%v.%v", model.FieldGroupTags, tag.Key)
+						filter[fieldName] = tag.Value
 						if t == 0 {
 							//add sort
-							query["sort"] = []string{tag.Key}
+							query["sort"] = []string{fieldName}
 						}
 						//cap at 30 filter max
 						if t == 30 {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -153,10 +153,10 @@ func TestResourcesPostRoute(t *testing.T) {
   "filter":{
     "$or":[
       {
-        "team":"infra"
+        "tags.team":"infra"
       },
       {
-        "team":"dev"
+        "tags.team":"dev"
       }
     ]
   }

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -110,7 +110,7 @@ func TestSearchByQuery(t *testing.T) {
 			//only one resource has enabled=true
 			query := `{
   "filter":{
-    "enabled": "true"
+    "tags.enabled": "true"
   }
 }`
 
@@ -123,11 +123,11 @@ func TestSearchByQuery(t *testing.T) {
 
 			//check 2 tags filter: both resources have both tags - 2 results
 			query = `{
-  "filter":{
-    "vpc":"vpc-123",
-    "eks:nodegroup":"staging-default"
-  }
-}`
+			  "filter":{
+			    "tags.vpc":"vpc-123",
+			    "tags.eks:nodegroup":"staging-default"
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resourcesRead.Resources))
@@ -136,17 +136,17 @@ func TestSearchByQuery(t *testing.T) {
 
 			//check 2 tags filter on same key - 2 results
 			query = `{
-  "filter":{
-    "$or":[
-      {
-        "team":"infra"
-      },
-      {
-        "team":"dev"
-      }
-    ]
-  }
-}`
+			  "filter":{
+			    "$or":[
+			      {
+			        "tags.team":"infra"
+			      },
+			      {
+			        "tags.team":"dev"
+			      }
+			    ]
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resourcesRead.Resources))
@@ -155,18 +155,18 @@ func TestSearchByQuery(t *testing.T) {
 
 			//check 2 tags filter on same key - 2 results
 			query = `{
-  "filter":{
-    "$or":[
-      {
-        "team":"infra"
-      },
-      {
-        "team":"dev"
-      }
-    ]
-  },
-  "limit": 1
-}`
+			  "filter":{
+			    "$or":[
+			      {
+			        "tags.team":"infra"
+			      },
+			      {
+			        "tags.team":"dev"
+			      }
+			    ]
+			  },
+			  "limit": 1
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(resourcesRead.Resources))
@@ -176,23 +176,23 @@ func TestSearchByQuery(t *testing.T) {
 			//first $or returns 2 instances
 			//second $or returns 1 instance --> result should be 1
 			query = `{
-  "filter":{
-    "$or":[
-      {
-        "team":"infra"
-      },
-      {
-        "team":"dev"
-      }
-    ],
-        "$and": [
-            { "$or": [
-                { "enabled": "true" },
-                { "enabled": "not-found" }
-            ] }
-        ]
-  }
-}`
+			  "filter":{
+			    "$or":[
+			      {
+			        "tags.team":"infra"
+			      },
+			      {
+			        "tags.team":"dev"
+			      }
+			    ],
+			        "$and": [
+			            { "$or": [
+			                { "tags.enabled": "true" },
+			                { "tags.enabled": "not-found" }
+			            ] }
+			        ]
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(resourcesRead.Resources))
@@ -204,30 +204,30 @@ func TestSearchByQuery(t *testing.T) {
 			//2. "enabled": "(not null) -> select both instances
 			//3. "id": "i-123" -> select 1 instance --> result should be 1
 			query = `{
-  "filter":{
-    "$or":[
-      {
-        "team":"(not null)"
-      }
-    ],
-    "$and":[
-      {
-        "$or":[
-          {
-            "enabled":"(not null)"
-          }
-        ]
-      },
-      {
-        "$or":[
-          {
-            "id":"i-123"
-          }
-        ]
-      }
-    ]
-  }
-}`
+			  "filter":{
+			    "$or":[
+			      {
+			        "tags.team":"(not null)"
+			      }
+			    ],
+			    "$and":[
+			      {
+			        "$or":[
+			          {
+			            "tags.enabled":"(not null)"
+			          }
+			        ]
+			      },
+			      {
+			        "$or":[
+			          {
+			            "core.id":"i-123"
+			          }
+			        ]
+			      }
+			    ]
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(resourcesRead.Resources))
@@ -236,11 +236,11 @@ func TestSearchByQuery(t *testing.T) {
 
 			//check 2 distinct tags - but no resource has both - 0 result
 			query = `{
-  "filter":{
-    "team":"dev",
-    "env":"prod"
-  }
-}`
+			  "filter":{
+			    "tags.team":"dev",
+			    "tags.env":"prod"
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(resourcesRead.Resources))
@@ -248,10 +248,10 @@ func TestSearchByQuery(t *testing.T) {
 
 			//tag present - 2 results
 			query = `{
-  "filter":{
-	  "team": { "$neq": "" }
-  }
-}`
+			  "filter":{
+				  "tags.team": { "$neq": "" }
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resourcesRead.Resources))
@@ -260,10 +260,10 @@ func TestSearchByQuery(t *testing.T) {
 
 			//test exclude - returns the resources without the tag release
 			query = `{
-  "filter":{
-    "release": "(missing)"
-  }
-}`
+			  "filter":{
+			    "tags.release": "(missing)"
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(resourcesRead.Resources))
@@ -272,11 +272,11 @@ func TestSearchByQuery(t *testing.T) {
 
 			//test 2 exclusions - the s3 bucket is the only one without both tags
 			query = `{
-  "filter":{
-    "release": "(missing)",
-    "debug:info": "(missing)"
-  }
-}`
+			  "filter":{
+			    "tags.release": "(missing)",
+			    "tags.debug:info": "(missing)"
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, resourcesRead.Count)
@@ -284,11 +284,11 @@ func TestSearchByQuery(t *testing.T) {
 
 			//mix include and exclude filters
 			query = `{
-  "filter":{
-    "release":"(not null)",
-    "vpc":"vpc-123"
-  }
-}`
+			  "filter":{
+			    "tags.release":"(not null)",
+			    "tags.vpc":"vpc-123"
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(resourcesRead.Resources))
@@ -296,7 +296,7 @@ func TestSearchByQuery(t *testing.T) {
 			testingutil.AssertEqualsResourcePter(t, resourceInst1, resourcesRead.Resources[0])
 
 			//test on max value
-			query = fmt.Sprintf(`{"filter":{"%v":"%v"}}`, tagMaxKey, tagMaxValue)
+			query = fmt.Sprintf(`{"filter":{"tags.%v":"%v"}}`, tagMaxKey, tagMaxValue)
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(resourcesRead.Resources))
@@ -304,19 +304,41 @@ func TestSearchByQuery(t *testing.T) {
 			testingutil.AssertEqualsResourcePter(t, resourceInst2, resourcesRead.Resources[0])
 
 			//test on a tag called region - find the tag (ignore the core field)
-			// we can probably revisit this in the future and include the group in the query field
-			//ex: support "tags.region":"us-west-2" and "core.region":"us-west-2"
 			query = `{
-  "filter":{
-    "region":"us-west-2"
-  }
-}`
+			  "filter":{
+			    "tags.region":"us-west-2"
+			  }
+			}`
 			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(resourcesRead.Resources))
 			assert.Equal(t, 1, resourcesRead.Count)
 			testingutil.AssertEqualsResourcePter(t, resourceInst1, resourcesRead.Resources[0])
 
+			//TODO remove this support when FE uses the new convention
+			//test backward compatibility until FE uses the new name convention for fields
+			query = `{
+  "filter":{
+    "enabled": "true"
+  }
+}`
+
+			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(resourcesRead.Resources))
+			assert.Equal(t, 1, resourcesRead.Count)
+			testingutil.AssertEqualsResourcePter(t, resourceInst1, resourcesRead.Resources[0])
+			query = `{
+  "filter":{
+    "id": "i-123"
+  }
+}`
+
+			resourcesRead, err = datastore.GetResources(ctx, []byte(query))
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(resourcesRead.Resources))
+			assert.Equal(t, 1, resourcesRead.Count)
+			testingutil.AssertEqualsResourcePter(t, resourceInst1, resourcesRead.Resources[0])
 		})
 	}
 }
@@ -412,7 +434,7 @@ func TestFields(t *testing.T) {
 			//only one resource has enabled=false
 			query := `{
   "filter":{
-    "enabled": "false"
+    "tags.enabled": "false"
   }
 }`
 

--- a/pkg/datastore/resourceindexer.go
+++ b/pkg/datastore/resourceindexer.go
@@ -55,7 +55,7 @@ func newResourceIndexer(ctx context.Context, logger *zap.Logger, db *gorm.DB) (r
 //an explicit field means that the column will be named after the field
 func (f fieldColumns) addExplicitFields(group string, names ...string) {
 	for _, name := range names {
-		f.addFieldColumn(group, fieldName(group, name), name)
+		f.addFieldColumn(fieldName(group, name), name)
 	}
 }
 
@@ -65,14 +65,14 @@ func (f fieldColumns) addDynamicFields(group string, names ...string) bool {
 	for _, name := range names {
 		fieldName := fieldName(group, name)
 		if _, found := f[fieldName]; !found {
-			f.addFieldColumn(group, fieldName, f.newColumnName())
+			f.addFieldColumn(fieldName, f.newColumnName())
 			newField = true
 		}
 	}
 	return newField
 }
 
-func (f fieldColumns) addFieldColumn(group, fieldName, columnName string) {
+func (f fieldColumns) addFieldColumn(fieldName, columnName string) {
 	f[fieldName] = fieldColumn{
 		ColumnName: columnName,
 		FieldName:  fieldName,

--- a/pkg/datastore/resourceindexer.go
+++ b/pkg/datastore/resourceindexer.go
@@ -52,39 +52,42 @@ func newResourceIndexer(ctx context.Context, logger *zap.Logger, db *gorm.DB) (r
 	return qb, err
 }
 
-//newFieldColumns creates the map from a slice of fieldColumn
-func newFieldColumns(fields []fieldColumn) fieldColumns {
-	result := make(map[string]fieldColumn)
-	for _, field := range fields {
-		result[field.FieldName] = field
-	}
-	return result
-}
-
 //an explicit field means that the column will be named after the field
-func (f fieldColumns) addExplicitFields(names ...string) {
+func (f fieldColumns) addExplicitFields(group string, names ...string) {
 	for _, name := range names {
-		f[name] = fieldColumn{
-			ColumnName: name,
-			FieldName:  name,
-		}
+		f.addFieldColumn(group, name, name)
 	}
 }
 
 //a dynamic field would have a generated column name
-func (f fieldColumns) addDynamicFields(names ...string) bool {
+func (f fieldColumns) addDynamicFields(group string, names ...string) bool {
 	newField := false
 	for _, name := range names {
 		if _, found := f[name]; !found {
-			columnName := f.newColumnName()
-			f[name] = fieldColumn{
-				ColumnName: columnName,
-				FieldName:  name,
-			}
+			f.addFieldColumn(group, name, f.newColumnName())
 			newField = true
 		}
 	}
 	return newField
+}
+
+func (f fieldColumns) addFieldColumn(group, name, columnName string) {
+	fieldName := fieldName(group, name)
+	f[fieldName] = fieldColumn{
+		ColumnName: columnName,
+		FieldName:  fieldName,
+	}
+}
+
+func fieldName(group string, name string) string {
+	return fmt.Sprintf("%v.%v", group, name)
+}
+
+func (f fieldColumns) columnName(group string, name string) string {
+	if v, ok := f[fieldName(group, name)]; ok {
+		return v.ColumnName
+	}
+	return ""
 }
 
 //note: this code is inneficient but only done when a new tag key is found (unfrequent)
@@ -115,11 +118,19 @@ func (f fieldColumns) asSlice() []fieldColumn {
 }
 
 //update a query field to map the datamodel
-//ex: "aws:ec2:fleet-id" -> "col_3"
+//ex: "tags.aws:ec2:fleet-id" -> "col_3"
 func (ri *resourceIndexer) toColumnName(fieldName string) string {
 	if fieldCol, ok := ri.fieldColumns[fieldName]; ok {
 		return fieldCol.ColumnName
 	}
+	//TODO remove this extra try once FE uses new field name convention
+	//this allows the query "team=consumer" to be equivalent to "tags.team=consumer"
+	for _, group := range []string{model.FieldGroupCore, model.FieldGroupTags} {
+		if fieldCol, ok := ri.fieldColumns[fmt.Sprintf("%v.%v", group, fieldName)]; ok {
+			return fieldCol.ColumnName
+		}
+	}
+
 	//do not do any change - rql would throw an unknown field error
 	return fieldName
 }
@@ -141,9 +152,12 @@ func (ri *resourceIndexer) rebuildDataModel(db *gorm.DB) error {
 			//load existing fields from the DB
 			db.Find(&fieldColumns)
 		}
-		ri.fieldColumns = newFieldColumns(fieldColumns)
+		ri.fieldColumns = make(map[string]fieldColumn)
+		for _, field := range fieldColumns {
+			ri.fieldColumns[field.FieldName] = field
+		}
 		//always include these
-		ri.fieldColumns.addExplicitFields("id", "type", "region")
+		ri.fieldColumns.addExplicitFields(model.FieldGroupCore, "id", "type", "region")
 	}
 
 	builder := dynamicstruct.NewStruct()
@@ -183,6 +197,7 @@ func (ri *resourceIndexer) rebuildDataModel(db *gorm.DB) error {
 	return nil
 }
 
+//updateQueryFields update the field name to use SQL column names
 func (ri *resourceIndexer) updateQueryFields(jsonQuery []byte) ([]byte, error) {
 	var query map[string]interface{}
 	err := json.Unmarshal(jsonQuery, &query)
@@ -211,10 +226,10 @@ func (ri *resourceIndexer) updateQueryFields(jsonQuery []byte) ([]byte, error) {
 func updateQueryFilter(filter map[string]interface{}, f func(string) string) map[string]interface{} {
 	/*{
 	  "filter":{
-	    "type":"ec2.Volume",
+	    "core.type":"ec2.Volume",
 	    "$or": [
-	      { "team": "marketplace" },
-	      { "team": "shipping" }
+	      { "tags.team": "marketplace" },
+	      { "tags.team": "shipping" }
 	    ]
 	  }
 	}
@@ -305,7 +320,7 @@ func (ri *resourceIndexer) writeResourceIndexes(ctx context.Context, db *gorm.DB
 	rebuildModel := false
 	for _, r := range resources {
 		for _, tag := range r.Tags {
-			if ri.fieldColumns.addDynamicFields(tag.Key) {
+			if ri.fieldColumns.addDynamicFields(model.FieldGroupTags, tag.Key) {
 				//new tag key found - need to rebuild the model
 				rebuildModel = true
 			}
@@ -339,8 +354,8 @@ func (ri *resourceIndexer) writeResourceIndexes(ctx context.Context, db *gorm.DB
 		row["region"] = r.Region
 		//add the tags
 		for _, tag := range r.Tags {
-			//ex: row["Col23"]="Jordan"
-			row[ri.fieldColumns[tag.Key].ColumnName] = tag.Value
+			//ex: row["Col23"]="Team"
+			row[ri.fieldColumns.columnName(model.FieldGroupTags, tag.Key)] = tag.Value
 		}
 		rows = append(rows, row)
 	}

--- a/pkg/datastore/resourceindexer.go
+++ b/pkg/datastore/resourceindexer.go
@@ -55,7 +55,7 @@ func newResourceIndexer(ctx context.Context, logger *zap.Logger, db *gorm.DB) (r
 //an explicit field means that the column will be named after the field
 func (f fieldColumns) addExplicitFields(group string, names ...string) {
 	for _, name := range names {
-		f.addFieldColumn(group, name, name)
+		f.addFieldColumn(group, fieldName(group, name), name)
 	}
 }
 
@@ -63,16 +63,16 @@ func (f fieldColumns) addExplicitFields(group string, names ...string) {
 func (f fieldColumns) addDynamicFields(group string, names ...string) bool {
 	newField := false
 	for _, name := range names {
-		if _, found := f[name]; !found {
-			f.addFieldColumn(group, name, f.newColumnName())
+		fieldName := fieldName(group, name)
+		if _, found := f[fieldName]; !found {
+			f.addFieldColumn(group, fieldName, f.newColumnName())
 			newField = true
 		}
 	}
 	return newField
 }
 
-func (f fieldColumns) addFieldColumn(group, name, columnName string) {
-	fieldName := fieldName(group, name)
+func (f fieldColumns) addFieldColumn(group, fieldName, columnName string) {
 	f[fieldName] = fieldColumn{
 		ColumnName: columnName,
 		FieldName:  fieldName,

--- a/pkg/datastore/resourceindexer_test.go
+++ b/pkg/datastore/resourceindexer_test.go
@@ -19,20 +19,20 @@ func TestUpdateQueryFields(t *testing.T) {
 	ri, err := newResourceIndexer(context.Background(), zaptest.NewLogger(t), nil)
 	//for this test we don't have a DB, we can still proceed
 	assert.Error(t, err, "no DB provided")
-	ri.fieldColumns.addExplicitFields("type", "region", "id")
+	ri.fieldColumns.addExplicitFields("core", "type", "region", "id")
 	assert.True(t,
-		ri.fieldColumns.addDynamicFields("aws:ec2:fleet-id", "team-name", "cluster", "env"),
+		ri.fieldColumns.addDynamicFields("tags", "aws:ec2:fleet-id", "team-name", "cluster", "env"),
 	)
 
 	testCases := []testCase{
 		{`{
   "limit":5,
   "filter":{
-    "type":"ec2.Instance",
-    "aws:ec2:fleet-id":"fleet-bafee5d7-215d-addb-2632-290ab09da4e7"
+    "core.type":"ec2.Instance",
+    "tags.aws:ec2:fleet-id":"fleet-bafee5d7-215d-addb-2632-290ab09da4e7"
   },
   "sort":[
-    "-aws:ec2:fleet-id"
+    "-tags.aws:ec2:fleet-id"
   ]
 }`, `{
   "limit":5,
@@ -46,9 +46,9 @@ func TestUpdateQueryFields(t *testing.T) {
 }`},
 		{`{
   "filter":{
-    "type": "s3.Bucket"
+    "core.type": "s3.Bucket"
   },
-  "sort": ["region"]
+  "sort": ["core.region"]
 }`, `{
   "filter":{
     "type": "s3.Bucket"
@@ -58,10 +58,10 @@ func TestUpdateQueryFields(t *testing.T) {
 		{
 			`{
   "filter":{
-    "type":"ec2.Volume",
+    "core.type":"ec2.Volume",
     "$or": [
-      { "team-name": "marketplace" },
-      { "team-name": "shipping" }
+      { "tags.team-name": "marketplace" },
+      { "tags.team-name": "shipping" }
     ]
   }
 }`,
@@ -78,12 +78,12 @@ func TestUpdateQueryFields(t *testing.T) {
 		{
 			`{
   "filter":{
-    "unknown-field":"ec2.Volume"
+    "tags.unknown-field":"ec2.Volume"
   }
 }`,
 			`{
   "filter":{
-    "unknown-field":"ec2.Volume"
+    "tags.unknown-field":"ec2.Volume"
   }
 }`,
 		},
@@ -91,12 +91,12 @@ func TestUpdateQueryFields(t *testing.T) {
 		{
 			`{
   "filter2":{
-    "aws:ec2:fleet-id":"fleet-bafee5d7-215d-addb-2632-290ab09da4e7"
+    "tags.aws:ec2:fleet-id":"fleet-bafee5d7-215d-addb-2632-290ab09da4e7"
   }
 }`,
 			`{
   "filter2":{
-    "aws:ec2:fleet-id":"fleet-bafee5d7-215d-addb-2632-290ab09da4e7"
+    "tags.aws:ec2:fleet-id":"fleet-bafee5d7-215d-addb-2632-290ab09da4e7"
   }
 }`,
 		},
@@ -104,19 +104,19 @@ func TestUpdateQueryFields(t *testing.T) {
 		{
 			`{
   "filter":{
-    "type":"ec2.Volume",
+    "core.type":"ec2.Volume",
     "$or": [
-      { "team-name": "marketplace" },
-      { "team-name": "shipping" }
+      { "tags.team-name": "marketplace" },
+      { "tags.team-name": "shipping" }
     ],
 	"$and": [
 		{ "$or": [
-			{ "cluster": "dev" },
-			{ "cluster": "prod" }
+			{ "tags.cluster": "dev" },
+			{ "tags.cluster": "prod" }
 		] },
 		{ "$or": [
-			{ "env": "staging" },
-			{ "env": "prod" }
+			{ "tags.env": "staging" },
+			{ "tags.env": "prod" }
 		] }
 	]
   }


### PR DESCRIPTION
Add a prefix on the field name used in the query, the prefix is the group name.
See the example below.
For backward compatibility, the existing syntax is still supported until we make the frontend changes. 
It will be deprecated then.

Previously
```js
  "filter":{
    "type":"ec2.Volume",
    "team": "marketplace"
  } 
 ```

With this PR
```js
  "filter":{
    "core.type":"ec2.Volume",
    "tags.team": "marketplace"
  } 
 ```