### PR TITLE
Use camel case for generated method names

### DIFF
--- a/hack/awsgen/generator/util.go
+++ b/hack/awsgen/generator/util.go
@@ -36,8 +36,8 @@ func linenumbers(in string) string {
 
 // fetchFuncName returns the name of the fetch (aka list) functions for a specific type
 func fetchFuncName(svc config.Service, typ config.Type) string {
-	return fmt.Sprintf(
-		"fetch_%s_%s",
+	return lowerCamelCaseJoin(
+		"fetch",
 		svc.Name,
 		typ.Name,
 	)
@@ -45,8 +45,8 @@ func fetchFuncName(svc config.Service, typ config.Type) string {
 
 // tagFuncName returns the name of the tags function for a specific type
 func tagFuncName(svc config.Service, typ config.Type) string {
-	return fmt.Sprintf(
-		"getTags_%s_%s",
+	return lowerCamelCaseJoin(
+		"getTags",
 		svc.Name,
 		typ.Name,
 	)
@@ -71,5 +71,28 @@ func resourceName(service config.Service, typ config.Type) string {
 
 // registerFuncName returns the name of the Go func that returns type mapping data for a specific service.
 func registerFuncName(svc config.Service) string {
-	return "register_" + svc.Name
+	return lowerCamelCaseJoin(
+		"register",
+		svc.Name,
+	)
+}
+
+// only ASCII supported
+func lowerCamelCaseJoin(parts ...string) string {
+	var out []string
+	for idx, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+
+		if idx > 0 {
+			firstChar := part[0:1]
+			firstChar = strings.ToUpper(firstChar)
+			part = firstChar + part[1:]
+		}
+
+		out = append(out, part)
+	}
+
+	return strings.Join(out, "")
 }

--- a/pkg/provider/aws/zz_autoscaling.go
+++ b/pkg/provider/aws/zz_autoscaling.go
@@ -10,10 +10,10 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_autoscaling(mapping map[string]mapper) {
+func (p *Provider) registerAutoscaling(mapping map[string]mapper) {
 	mapping["autoscaling.AutoScalingGroup"] = mapper{
 		ServiceEndpointID: "autoscaling",
-		FetchFunc:         p.fetch_autoscaling_AutoScalingGroup,
+		FetchFunc:         p.fetchAutoscalingAutoScalingGroup,
 		IdField:           "AutoScalingGroupName",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -24,7 +24,7 @@ func (p *Provider) register_autoscaling(mapping map[string]mapper) {
 	}
 }
 
-func (p *Provider) fetch_autoscaling_AutoScalingGroup(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchAutoscalingAutoScalingGroup(ctx context.Context, output chan<- model.Resource) error {
 	client := autoscaling.NewFromConfig(p.config)
 	input := &autoscaling.DescribeAutoScalingGroupsInput{}
 

--- a/pkg/provider/aws/zz_ec2.go
+++ b/pkg/provider/aws/zz_ec2.go
@@ -10,10 +10,10 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_ec2(mapping map[string]mapper) {
+func (p *Provider) registerEc2(mapping map[string]mapper) {
 	mapping["ec2.Address"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Address,
+		FetchFunc:         p.fetchEc2Address,
 		IdField:           "AllocationId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -24,7 +24,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.CapacityReservation"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_CapacityReservation,
+		FetchFunc:         p.fetchEc2CapacityReservation,
 		IdField:           "CapacityReservationId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -35,7 +35,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.ClientVpnEndpoint"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_ClientVpnEndpoint,
+		FetchFunc:         p.fetchEc2ClientVpnEndpoint,
 		IdField:           "ClientVpnEndpointId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -46,7 +46,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Fleet"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Fleet,
+		FetchFunc:         p.fetchEc2Fleet,
 		IdField:           "FleetId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -57,7 +57,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.FlowLogs"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_FlowLogs,
+		FetchFunc:         p.fetchEc2FlowLogs,
 		IdField:           "FlowLogId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -68,7 +68,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Image"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Image,
+		FetchFunc:         p.fetchEc2Image,
 		IdField:           "ImageId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -79,7 +79,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Instance"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Instance,
+		FetchFunc:         p.fetchEc2Instance,
 		IdField:           "InstanceId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -90,7 +90,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.KeyPair"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_KeyPair,
+		FetchFunc:         p.fetchEc2KeyPair,
 		IdField:           "KeyPairId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -101,7 +101,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.LaunchTemplate"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_LaunchTemplate,
+		FetchFunc:         p.fetchEc2LaunchTemplate,
 		IdField:           "LaunchTemplateId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -112,7 +112,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.NatGateway"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_NatGateway,
+		FetchFunc:         p.fetchEc2NatGateway,
 		IdField:           "NatGatewayId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -123,7 +123,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.NetworkAcl"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_NetworkAcl,
+		FetchFunc:         p.fetchEc2NetworkAcl,
 		IdField:           "NetworkAclId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -134,7 +134,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.NetworkInterface"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_NetworkInterface,
+		FetchFunc:         p.fetchEc2NetworkInterface,
 		IdField:           "NetworkInterfaceId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -145,7 +145,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.ReservedInstance"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_ReservedInstance,
+		FetchFunc:         p.fetchEc2ReservedInstance,
 		IdField:           "ReservedInstancesId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -156,7 +156,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.RouteTable"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_RouteTable,
+		FetchFunc:         p.fetchEc2RouteTable,
 		IdField:           "RouteTableId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -167,7 +167,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.SecurityGroup"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_SecurityGroup,
+		FetchFunc:         p.fetchEc2SecurityGroup,
 		IdField:           "GroupId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -178,7 +178,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Snapshot"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Snapshot,
+		FetchFunc:         p.fetchEc2Snapshot,
 		IdField:           "SnapshotId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -189,7 +189,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.SpotInstanceRequest"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_SpotInstanceRequest,
+		FetchFunc:         p.fetchEc2SpotInstanceRequest,
 		IdField:           "SpotInstanceRequestId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -200,7 +200,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Subnet"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Subnet,
+		FetchFunc:         p.fetchEc2Subnet,
 		IdField:           "SubnetId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -211,7 +211,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Volume"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Volume,
+		FetchFunc:         p.fetchEc2Volume,
 		IdField:           "VolumeId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -222,7 +222,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 	mapping["ec2.Vpc"] = mapper{
 		ServiceEndpointID: "ec2",
-		FetchFunc:         p.fetch_ec2_Vpc,
+		FetchFunc:         p.fetchEc2Vpc,
 		IdField:           "VpcId",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -233,7 +233,7 @@ func (p *Provider) register_ec2(mapping map[string]mapper) {
 	}
 }
 
-func (p *Provider) fetch_ec2_Address(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Address(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeAddressesInput{}
 
@@ -249,7 +249,7 @@ func (p *Provider) fetch_ec2_Address(ctx context.Context, output chan<- model.Re
 	return nil
 }
 
-func (p *Provider) fetch_ec2_CapacityReservation(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2CapacityReservation(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeCapacityReservationsInput{}
 	input.Filters = describeCapacityReservationsFilters()
@@ -271,7 +271,7 @@ func (p *Provider) fetch_ec2_CapacityReservation(ctx context.Context, output cha
 	return nil
 }
 
-func (p *Provider) fetch_ec2_ClientVpnEndpoint(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2ClientVpnEndpoint(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeClientVpnEndpointsInput{}
 
@@ -292,7 +292,7 @@ func (p *Provider) fetch_ec2_ClientVpnEndpoint(ctx context.Context, output chan<
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Fleet(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Fleet(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeFleetsInput{}
 	input.Filters = describeFleetsFilters()
@@ -314,7 +314,7 @@ func (p *Provider) fetch_ec2_Fleet(ctx context.Context, output chan<- model.Reso
 	return nil
 }
 
-func (p *Provider) fetch_ec2_FlowLogs(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2FlowLogs(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeFlowLogsInput{}
 
@@ -335,7 +335,7 @@ func (p *Provider) fetch_ec2_FlowLogs(ctx context.Context, output chan<- model.R
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Image(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Image(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeImagesInput{}
 	input.Owners = describeImagesOwners()
@@ -352,7 +352,7 @@ func (p *Provider) fetch_ec2_Image(ctx context.Context, output chan<- model.Reso
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Instance(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Instance(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeInstancesInput{}
 	input.Filters = describeInstancesFilters()
@@ -376,7 +376,7 @@ func (p *Provider) fetch_ec2_Instance(ctx context.Context, output chan<- model.R
 	return nil
 }
 
-func (p *Provider) fetch_ec2_KeyPair(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2KeyPair(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeKeyPairsInput{}
 
@@ -392,7 +392,7 @@ func (p *Provider) fetch_ec2_KeyPair(ctx context.Context, output chan<- model.Re
 	return nil
 }
 
-func (p *Provider) fetch_ec2_LaunchTemplate(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2LaunchTemplate(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeLaunchTemplatesInput{}
 
@@ -413,7 +413,7 @@ func (p *Provider) fetch_ec2_LaunchTemplate(ctx context.Context, output chan<- m
 	return nil
 }
 
-func (p *Provider) fetch_ec2_NatGateway(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2NatGateway(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeNatGatewaysInput{}
 
@@ -434,7 +434,7 @@ func (p *Provider) fetch_ec2_NatGateway(ctx context.Context, output chan<- model
 	return nil
 }
 
-func (p *Provider) fetch_ec2_NetworkAcl(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2NetworkAcl(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeNetworkAclsInput{}
 
@@ -455,7 +455,7 @@ func (p *Provider) fetch_ec2_NetworkAcl(ctx context.Context, output chan<- model
 	return nil
 }
 
-func (p *Provider) fetch_ec2_NetworkInterface(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2NetworkInterface(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeNetworkInterfacesInput{}
 
@@ -476,7 +476,7 @@ func (p *Provider) fetch_ec2_NetworkInterface(ctx context.Context, output chan<-
 	return nil
 }
 
-func (p *Provider) fetch_ec2_ReservedInstance(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2ReservedInstance(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeReservedInstancesInput{}
 	input.Filters = describeReservedInstancesFilters()
@@ -493,7 +493,7 @@ func (p *Provider) fetch_ec2_ReservedInstance(ctx context.Context, output chan<-
 	return nil
 }
 
-func (p *Provider) fetch_ec2_RouteTable(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2RouteTable(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeRouteTablesInput{}
 
@@ -514,7 +514,7 @@ func (p *Provider) fetch_ec2_RouteTable(ctx context.Context, output chan<- model
 	return nil
 }
 
-func (p *Provider) fetch_ec2_SecurityGroup(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2SecurityGroup(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeSecurityGroupsInput{}
 
@@ -535,7 +535,7 @@ func (p *Provider) fetch_ec2_SecurityGroup(ctx context.Context, output chan<- mo
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Snapshot(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Snapshot(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeSnapshotsInput{}
 	input.OwnerIds = describeSnapshotsOwners()
@@ -557,7 +557,7 @@ func (p *Provider) fetch_ec2_Snapshot(ctx context.Context, output chan<- model.R
 	return nil
 }
 
-func (p *Provider) fetch_ec2_SpotInstanceRequest(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2SpotInstanceRequest(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeSpotInstanceRequestsInput{}
 	input.Filters = describeSpotInstanceRequestsFilters()
@@ -579,7 +579,7 @@ func (p *Provider) fetch_ec2_SpotInstanceRequest(ctx context.Context, output cha
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Subnet(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Subnet(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeSubnetsInput{}
 
@@ -600,7 +600,7 @@ func (p *Provider) fetch_ec2_Subnet(ctx context.Context, output chan<- model.Res
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Volume(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Volume(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeVolumesInput{}
 
@@ -621,7 +621,7 @@ func (p *Provider) fetch_ec2_Volume(ctx context.Context, output chan<- model.Res
 	return nil
 }
 
-func (p *Provider) fetch_ec2_Vpc(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchEc2Vpc(ctx context.Context, output chan<- model.Resource) error {
 	client := ec2.NewFromConfig(p.config)
 	input := &ec2.DescribeVpcsInput{}
 

--- a/pkg/provider/aws/zz_elasticache.go
+++ b/pkg/provider/aws/zz_elasticache.go
@@ -11,16 +11,16 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_elasticache(mapping map[string]mapper) {
+func (p *Provider) registerElasticache(mapping map[string]mapper) {
 	mapping["elasticache.CacheCluster"] = mapper{
 		ServiceEndpointID: "elasticache",
-		FetchFunc:         p.fetch_elasticache_CacheCluster,
+		FetchFunc:         p.fetchElasticacheCacheCluster,
 		IdField:           "ARN",
 		IsGlobal:          false,
 	}
 }
 
-func (p *Provider) fetch_elasticache_CacheCluster(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchElasticacheCacheCluster(ctx context.Context, output chan<- model.Resource) error {
 	client := elasticache.NewFromConfig(p.config)
 	input := &elasticache.DescribeCacheClustersInput{}
 
@@ -33,14 +33,14 @@ func (p *Provider) fetch_elasticache_CacheCluster(ctx context.Context, output ch
 			return fmt.Errorf("failed to fetch %s: %w", "elasticache.CacheCluster", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.CacheClusters, p.getTags_elasticache_CacheCluster); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.CacheClusters, p.getTagsElasticacheCacheCluster); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_elasticache_CacheCluster(ctx context.Context, resource types.CacheCluster) (model.Tags, error) {
+func (p *Provider) getTagsElasticacheCacheCluster(ctx context.Context, resource types.CacheCluster) (model.Tags, error) {
 	client := elasticache.NewFromConfig(p.config)
 	input := &elasticache.ListTagsForResourceInput{}
 

--- a/pkg/provider/aws/zz_elb.go
+++ b/pkg/provider/aws/zz_elb.go
@@ -11,16 +11,16 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_elb(mapping map[string]mapper) {
+func (p *Provider) registerElb(mapping map[string]mapper) {
 	mapping["elb.LoadBalancer"] = mapper{
 		ServiceEndpointID: "elasticloadbalancing",
-		FetchFunc:         p.fetch_elb_LoadBalancer,
+		FetchFunc:         p.fetchElbLoadBalancer,
 		IdField:           "LoadBalancerArn",
 		IsGlobal:          false,
 	}
 }
 
-func (p *Provider) fetch_elb_LoadBalancer(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchElbLoadBalancer(ctx context.Context, output chan<- model.Resource) error {
 	client := elasticloadbalancingv2.NewFromConfig(p.config)
 	input := &elasticloadbalancingv2.DescribeLoadBalancersInput{}
 
@@ -33,14 +33,14 @@ func (p *Provider) fetch_elb_LoadBalancer(ctx context.Context, output chan<- mod
 			return fmt.Errorf("failed to fetch %s: %w", "elb.LoadBalancer", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.LoadBalancers, p.getTags_elb_LoadBalancer); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.LoadBalancers, p.getTagsElbLoadBalancer); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_elb_LoadBalancer(ctx context.Context, resource types.LoadBalancer) (model.Tags, error) {
+func (p *Provider) getTagsElbLoadBalancer(ctx context.Context, resource types.LoadBalancer) (model.Tags, error) {
 	client := elasticloadbalancingv2.NewFromConfig(p.config)
 	input := &elasticloadbalancingv2.DescribeTagsInput{}
 

--- a/pkg/provider/aws/zz_iam.go
+++ b/pkg/provider/aws/zz_iam.go
@@ -11,35 +11,35 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_iam(mapping map[string]mapper) {
+func (p *Provider) registerIam(mapping map[string]mapper) {
 	mapping["iam.OpenIDConnectProvider"] = mapper{
 		ServiceEndpointID: "iam",
-		FetchFunc:         p.fetch_iam_OpenIDConnectProvider,
+		FetchFunc:         p.fetchIamOpenIDConnectProvider,
 		IdField:           "Arn",
 		IsGlobal:          true,
 	}
 	mapping["iam.Policy"] = mapper{
 		ServiceEndpointID: "iam",
-		FetchFunc:         p.fetch_iam_Policy,
+		FetchFunc:         p.fetchIamPolicy,
 		IdField:           "Arn",
 		DisplayIDField:    "PolicyName",
 		IsGlobal:          true,
 	}
 	mapping["iam.SAMLProvider"] = mapper{
 		ServiceEndpointID: "iam",
-		FetchFunc:         p.fetch_iam_SAMLProvider,
+		FetchFunc:         p.fetchIamSAMLProvider,
 		IdField:           "Arn",
 		IsGlobal:          true,
 	}
 	mapping["iam.VirtualMFADevice"] = mapper{
 		ServiceEndpointID: "iam",
-		FetchFunc:         p.fetch_iam_VirtualMFADevice,
+		FetchFunc:         p.fetchIamVirtualMFADevice,
 		IdField:           "SerialNumber",
 		IsGlobal:          true,
 	}
 }
 
-func (p *Provider) fetch_iam_OpenIDConnectProvider(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchIamOpenIDConnectProvider(ctx context.Context, output chan<- model.Resource) error {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListOpenIDConnectProvidersInput{}
 
@@ -48,13 +48,13 @@ func (p *Provider) fetch_iam_OpenIDConnectProvider(ctx context.Context, output c
 	if err != nil {
 		return fmt.Errorf("failed to fetch %s: %w", "iam.OpenIDConnectProvider", err)
 	}
-	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, results.OpenIDConnectProviderList, p.getTags_iam_OpenIDConnectProvider); err != nil {
+	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, results.OpenIDConnectProviderList, p.getTagsIamOpenIDConnectProvider); err != nil {
 		return err
 	}
 
 	return nil
 }
-func (p *Provider) getTags_iam_OpenIDConnectProvider(ctx context.Context, resource types.OpenIDConnectProviderListEntry) (model.Tags, error) {
+func (p *Provider) getTagsIamOpenIDConnectProvider(ctx context.Context, resource types.OpenIDConnectProviderListEntry) (model.Tags, error) {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListOpenIDConnectProviderTagsInput{}
 
@@ -78,7 +78,7 @@ func (p *Provider) getTags_iam_OpenIDConnectProvider(ctx context.Context, resour
 	return tags, nil
 }
 
-func (p *Provider) fetch_iam_Policy(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchIamPolicy(ctx context.Context, output chan<- model.Resource) error {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListPoliciesInput{}
 	input.Scope = listPoliciesScope()
@@ -92,14 +92,14 @@ func (p *Provider) fetch_iam_Policy(ctx context.Context, output chan<- model.Res
 			return fmt.Errorf("failed to fetch %s: %w", "iam.Policy", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Policies, p.getTags_iam_Policy); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Policies, p.getTagsIamPolicy); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_iam_Policy(ctx context.Context, resource types.Policy) (model.Tags, error) {
+func (p *Provider) getTagsIamPolicy(ctx context.Context, resource types.Policy) (model.Tags, error) {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListPolicyTagsInput{}
 
@@ -123,7 +123,7 @@ func (p *Provider) getTags_iam_Policy(ctx context.Context, resource types.Policy
 	return tags, nil
 }
 
-func (p *Provider) fetch_iam_SAMLProvider(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchIamSAMLProvider(ctx context.Context, output chan<- model.Resource) error {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListSAMLProvidersInput{}
 
@@ -132,13 +132,13 @@ func (p *Provider) fetch_iam_SAMLProvider(ctx context.Context, output chan<- mod
 	if err != nil {
 		return fmt.Errorf("failed to fetch %s: %w", "iam.SAMLProvider", err)
 	}
-	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, results.SAMLProviderList, p.getTags_iam_SAMLProvider); err != nil {
+	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, results.SAMLProviderList, p.getTagsIamSAMLProvider); err != nil {
 		return err
 	}
 
 	return nil
 }
-func (p *Provider) getTags_iam_SAMLProvider(ctx context.Context, resource types.SAMLProviderListEntry) (model.Tags, error) {
+func (p *Provider) getTagsIamSAMLProvider(ctx context.Context, resource types.SAMLProviderListEntry) (model.Tags, error) {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListSAMLProviderTagsInput{}
 
@@ -162,7 +162,7 @@ func (p *Provider) getTags_iam_SAMLProvider(ctx context.Context, resource types.
 	return tags, nil
 }
 
-func (p *Provider) fetch_iam_VirtualMFADevice(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchIamVirtualMFADevice(ctx context.Context, output chan<- model.Resource) error {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListVirtualMFADevicesInput{}
 
@@ -175,14 +175,14 @@ func (p *Provider) fetch_iam_VirtualMFADevice(ctx context.Context, output chan<-
 			return fmt.Errorf("failed to fetch %s: %w", "iam.VirtualMFADevice", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.VirtualMFADevices, p.getTags_iam_VirtualMFADevice); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.VirtualMFADevices, p.getTagsIamVirtualMFADevice); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_iam_VirtualMFADevice(ctx context.Context, resource types.VirtualMFADevice) (model.Tags, error) {
+func (p *Provider) getTagsIamVirtualMFADevice(ctx context.Context, resource types.VirtualMFADevice) (model.Tags, error) {
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListMFADeviceTagsInput{}
 

--- a/pkg/provider/aws/zz_lambda.go
+++ b/pkg/provider/aws/zz_lambda.go
@@ -11,16 +11,16 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_lambda(mapping map[string]mapper) {
+func (p *Provider) registerLambda(mapping map[string]mapper) {
 	mapping["lambda.Function"] = mapper{
 		ServiceEndpointID: "lambda",
-		FetchFunc:         p.fetch_lambda_Function,
+		FetchFunc:         p.fetchLambdaFunction,
 		IdField:           "FunctionArn",
 		IsGlobal:          false,
 	}
 }
 
-func (p *Provider) fetch_lambda_Function(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchLambdaFunction(ctx context.Context, output chan<- model.Resource) error {
 	client := lambda.NewFromConfig(p.config)
 	input := &lambda.ListFunctionsInput{}
 
@@ -33,14 +33,14 @@ func (p *Provider) fetch_lambda_Function(ctx context.Context, output chan<- mode
 			return fmt.Errorf("failed to fetch %s: %w", "lambda.Function", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Functions, p.getTags_lambda_Function); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Functions, p.getTagsLambdaFunction); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_lambda_Function(ctx context.Context, resource types.FunctionConfiguration) (model.Tags, error) {
+func (p *Provider) getTagsLambdaFunction(ctx context.Context, resource types.FunctionConfiguration) (model.Tags, error) {
 	client := lambda.NewFromConfig(p.config)
 	input := &lambda.GetFunctionInput{}
 

--- a/pkg/provider/aws/zz_rds.go
+++ b/pkg/provider/aws/zz_rds.go
@@ -10,10 +10,10 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_rds(mapping map[string]mapper) {
+func (p *Provider) registerRds(mapping map[string]mapper) {
 	mapping["rds.DBCluster"] = mapper{
 		ServiceEndpointID: "rds",
-		FetchFunc:         p.fetch_rds_DBCluster,
+		FetchFunc:         p.fetchRdsDBCluster,
 		IdField:           "DBClusterIdentifier",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -24,7 +24,7 @@ func (p *Provider) register_rds(mapping map[string]mapper) {
 	}
 	mapping["rds.DBClusterSnapshot"] = mapper{
 		ServiceEndpointID: "rds",
-		FetchFunc:         p.fetch_rds_DBClusterSnapshot,
+		FetchFunc:         p.fetchRdsDBClusterSnapshot,
 		IdField:           "DBClusterSnapshotIdentifier",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -35,7 +35,7 @@ func (p *Provider) register_rds(mapping map[string]mapper) {
 	}
 	mapping["rds.DBInstance"] = mapper{
 		ServiceEndpointID: "rds",
-		FetchFunc:         p.fetch_rds_DBInstance,
+		FetchFunc:         p.fetchRdsDBInstance,
 		IdField:           "DBInstanceIdentifier",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -46,7 +46,7 @@ func (p *Provider) register_rds(mapping map[string]mapper) {
 	}
 	mapping["rds.DBSnapshot"] = mapper{
 		ServiceEndpointID: "rds",
-		FetchFunc:         p.fetch_rds_DBSnapshot,
+		FetchFunc:         p.fetchRdsDBSnapshot,
 		IdField:           "DBSnapshotIdentifier",
 		IsGlobal:          false,
 		TagField: resourceconverter.TagField{
@@ -57,7 +57,7 @@ func (p *Provider) register_rds(mapping map[string]mapper) {
 	}
 }
 
-func (p *Provider) fetch_rds_DBCluster(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchRdsDBCluster(ctx context.Context, output chan<- model.Resource) error {
 	client := rds.NewFromConfig(p.config)
 	input := &rds.DescribeDBClustersInput{}
 
@@ -78,7 +78,7 @@ func (p *Provider) fetch_rds_DBCluster(ctx context.Context, output chan<- model.
 	return nil
 }
 
-func (p *Provider) fetch_rds_DBClusterSnapshot(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchRdsDBClusterSnapshot(ctx context.Context, output chan<- model.Resource) error {
 	client := rds.NewFromConfig(p.config)
 	input := &rds.DescribeDBClusterSnapshotsInput{}
 
@@ -99,7 +99,7 @@ func (p *Provider) fetch_rds_DBClusterSnapshot(ctx context.Context, output chan<
 	return nil
 }
 
-func (p *Provider) fetch_rds_DBInstance(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchRdsDBInstance(ctx context.Context, output chan<- model.Resource) error {
 	client := rds.NewFromConfig(p.config)
 	input := &rds.DescribeDBInstancesInput{}
 
@@ -120,7 +120,7 @@ func (p *Provider) fetch_rds_DBInstance(ctx context.Context, output chan<- model
 	return nil
 }
 
-func (p *Provider) fetch_rds_DBSnapshot(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchRdsDBSnapshot(ctx context.Context, output chan<- model.Resource) error {
 	client := rds.NewFromConfig(p.config)
 	input := &rds.DescribeDBSnapshotsInput{}
 

--- a/pkg/provider/aws/zz_register.go
+++ b/pkg/provider/aws/zz_register.go
@@ -3,13 +3,13 @@ package aws
 import ()
 
 func (p *Provider) registerGeneratedTypes(mapping map[string]mapper) {
-	p.register_autoscaling(mapping)
-	p.register_ec2(mapping)
-	p.register_elasticache(mapping)
-	p.register_elb(mapping)
-	p.register_iam(mapping)
-	p.register_lambda(mapping)
-	p.register_rds(mapping)
-	p.register_route53(mapping)
-	p.register_sns(mapping)
+	p.registerAutoscaling(mapping)
+	p.registerEc2(mapping)
+	p.registerElasticache(mapping)
+	p.registerElb(mapping)
+	p.registerIam(mapping)
+	p.registerLambda(mapping)
+	p.registerRds(mapping)
+	p.registerRoute53(mapping)
+	p.registerSns(mapping)
 }

--- a/pkg/provider/aws/zz_route53.go
+++ b/pkg/provider/aws/zz_route53.go
@@ -11,23 +11,23 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_route53(mapping map[string]mapper) {
+func (p *Provider) registerRoute53(mapping map[string]mapper) {
 	mapping["route53.HealthCheck"] = mapper{
 		ServiceEndpointID: "route53",
-		FetchFunc:         p.fetch_route53_HealthCheck,
+		FetchFunc:         p.fetchRoute53HealthCheck,
 		IdField:           "Id",
 		IsGlobal:          true,
 	}
 	mapping["route53.HostedZone"] = mapper{
 		ServiceEndpointID: "route53",
-		FetchFunc:         p.fetch_route53_HostedZone,
+		FetchFunc:         p.fetchRoute53HostedZone,
 		IdField:           "Id",
 		DisplayIDField:    "Name",
 		IsGlobal:          true,
 	}
 }
 
-func (p *Provider) fetch_route53_HealthCheck(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchRoute53HealthCheck(ctx context.Context, output chan<- model.Resource) error {
 	client := route53.NewFromConfig(p.config)
 	input := &route53.ListHealthChecksInput{}
 
@@ -40,14 +40,14 @@ func (p *Provider) fetch_route53_HealthCheck(ctx context.Context, output chan<- 
 			return fmt.Errorf("failed to fetch %s: %w", "route53.HealthCheck", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.HealthChecks, p.getTags_route53_HealthCheck); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.HealthChecks, p.getTagsRoute53HealthCheck); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_route53_HealthCheck(ctx context.Context, resource types.HealthCheck) (model.Tags, error) {
+func (p *Provider) getTagsRoute53HealthCheck(ctx context.Context, resource types.HealthCheck) (model.Tags, error) {
 	client := route53.NewFromConfig(p.config)
 	input := &route53.ListTagsForResourcesInput{}
 
@@ -81,7 +81,7 @@ func (p *Provider) getTags_route53_HealthCheck(ctx context.Context, resource typ
 	return tags, nil
 }
 
-func (p *Provider) fetch_route53_HostedZone(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchRoute53HostedZone(ctx context.Context, output chan<- model.Resource) error {
 	client := route53.NewFromConfig(p.config)
 	input := &route53.ListHostedZonesInput{}
 
@@ -94,14 +94,14 @@ func (p *Provider) fetch_route53_HostedZone(ctx context.Context, output chan<- m
 			return fmt.Errorf("failed to fetch %s: %w", "route53.HostedZone", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.HostedZones, p.getTags_route53_HostedZone); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.HostedZones, p.getTagsRoute53HostedZone); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_route53_HostedZone(ctx context.Context, resource types.HostedZone) (model.Tags, error) {
+func (p *Provider) getTagsRoute53HostedZone(ctx context.Context, resource types.HostedZone) (model.Tags, error) {
 	client := route53.NewFromConfig(p.config)
 	input := &route53.ListTagsForResourcesInput{}
 

--- a/pkg/provider/aws/zz_sns.go
+++ b/pkg/provider/aws/zz_sns.go
@@ -11,16 +11,16 @@ import (
 	"github.com/run-x/cloudgrep/pkg/resourceconverter"
 )
 
-func (p *Provider) register_sns(mapping map[string]mapper) {
+func (p *Provider) registerSns(mapping map[string]mapper) {
 	mapping["sns.Topic"] = mapper{
 		ServiceEndpointID: "sns",
-		FetchFunc:         p.fetch_sns_Topic,
+		FetchFunc:         p.fetchSnsTopic,
 		IdField:           "TopicArn",
 		IsGlobal:          false,
 	}
 }
 
-func (p *Provider) fetch_sns_Topic(ctx context.Context, output chan<- model.Resource) error {
+func (p *Provider) fetchSnsTopic(ctx context.Context, output chan<- model.Resource) error {
 	client := sns.NewFromConfig(p.config)
 	input := &sns.ListTopicsInput{}
 
@@ -33,14 +33,14 @@ func (p *Provider) fetch_sns_Topic(ctx context.Context, output chan<- model.Reso
 			return fmt.Errorf("failed to fetch %s: %w", "sns.Topic", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Topics, p.getTags_sns_Topic); err != nil {
+		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Topics, p.getTagsSnsTopic); err != nil {
 			return err
 		}
 	}
 
 	return nil
 }
-func (p *Provider) getTags_sns_Topic(ctx context.Context, resource types.Topic) (model.Tags, error) {
+func (p *Provider) getTagsSnsTopic(ctx context.Context, resource types.Topic) (model.Tags, error) {
 	client := sns.NewFromConfig(p.config)
 	input := &sns.ListTagsForResourceInput{}
 


### PR DESCRIPTION
This updates the methods built by autogeneration to use camel case instead of snake case, to align with Go convention.