### PR TITLE
Assume AWS role option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,29 @@ cloudgrep --help
 ```
 
 
-To specify the AWS regions, you can use the `--regions` flag.
+To specify the AWS region(s), you can use the `--regions` flag.
 ```bash
 # will scan using the default AWS credentials for regions us-east-1,us-west-2
 cloudgrep --regions us-east-1,us-west-2
 ```
 
-To use multiple AWS accounts, you can use the `--profiles` flag.
+To use multiple AWS account(s), you can use the `--profiles` flag.
 ```bash
 # will scan 2 accounts using the AWS profiles called "dev" and "prod", using the default region for each profile
 cloudgrep --profiles dev,prod
 
 # combine regions and profiles
 cloudgrep --profiles dev,prod --regions us-east-1,us-west-2
+```
+
+To assume some AWS roles(s), you can use the `--role-arns` flag.
+```bash
+# will assume the provided role
+cloudgrep --role-arns arn:aws:iam::123456789012:role/ReadOnlyAcces
+
+# will use the 'dev' profile and then assume the provided role
+cloudgrep  --profiles dev --role-arns arn:aws:iam::123456789012:role/ReadOnlyAcces
+
 ```
 
 # Advanced Usage
@@ -163,6 +173,10 @@ providers:
 
     # use a specific AWS profile
     # profile: dev-AKIAXXXXXXXXXXXXXX
+
+    # use a specific AWS role
+    # roleArn: arn:aws:iam::123456789012:role/ReadOnlyAcces
+
 
 ```
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -94,19 +94,29 @@ cloudgrep --help
 ```
 
 
-To specify the AWS regions, you can use the `--regions` flag.
+To specify the AWS region(s), you can use the `--regions` flag.
 ```bash
 # will scan using the default AWS credentials for regions us-east-1,us-west-2
 cloudgrep --regions us-east-1,us-west-2
 ```
 
-To use multiple AWS accounts, you can use the `--profiles` flag.
+To use multiple AWS account(s), you can use the `--profiles` flag.
 ```bash
 # will scan 2 accounts using the AWS profiles called "dev" and "prod", using the default region for each profile
 cloudgrep --profiles dev,prod
 
 # combine regions and profiles
 cloudgrep --profiles dev,prod --regions us-east-1,us-west-2
+```
+
+To assume some AWS roles(s), you can use the `--role-arns` flag.
+```bash
+# will assume the provided role
+cloudgrep --role-arns arn:aws:iam::123456789012:role/ReadOnlyAcces
+
+# will use the 'dev' profile and then assume the provided role
+cloudgrep  --profiles dev --role-arns arn:aws:iam::123456789012:role/ReadOnlyAcces
+
 ```
 
 # Advanced Usage

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ type rootOptions struct {
 	bind        string
 	regions     []string
 	profiles    []string
+	roles       []string
 	port        int
 	prefix      string
 	skipOpen    bool
@@ -42,6 +43,7 @@ func (rO rootOptions) loadConfig() (config.Config, error) {
 	}
 	cfg.Regions = rO.regions
 	cfg.Profiles = rO.profiles
+	cfg.RoleArns = rO.roles
 	if rO.port != 0 {
 		cfg.Web.Port = rO.port
 	}
@@ -98,6 +100,7 @@ their cloud accounts.`,
 	flags.StringVar(&rO.bind, "bind", "", "Host to bind on")
 	flags.StringSliceVarP(&rO.regions, "regions", "r", []string(nil), "Comma separated list of regions to scan, or \"all\"")
 	flags.StringSliceVar(&rO.profiles, "profiles", []string(nil), "Comma separated list of AWS profiles to scan.")
+	flags.StringSliceVar(&rO.roles, "role-arns", []string(nil), "Comma separated list of AWS role ARNs to assume.")
 	flags.IntVarP(&rO.port, "port", "p", 0, "Port to use")
 	flags.StringVar(&rO.prefix, "prefix", "", "URL prefix to use")
 	flags.BoolVar(&rO.skipOpen, "skip-open", false, "Skip running the open command to open default browser")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,35 +31,31 @@ func TestRootCommand(t *testing.T) {
 		port     int
 		regions  []string
 		profiles []string
+		roles    []string
 		verbose  bool
 		args     []string
 	}{
 		{
-			name:     "default",
-			host:     "localhost",
-			port:     8080,
-			regions:  []string(nil),
-			profiles: []string(nil),
-			verbose:  false,
-			args:     []string{},
+			name: "default",
+			host: "localhost",
+			port: 8080,
 		},
 		{
-			name:     "-p 8081 -r us-west-1,us-west-2 -v",
-			host:     "localhost",
-			port:     8081,
-			regions:  []string{"us-west-1", "us-west-2"},
-			profiles: []string(nil),
-			verbose:  true,
-			args:     []string{"-p", "8081", "-v", "-r", "us-west-1,us-west-2"},
+			name:    "-p 8081 -r us-west-1,us-west-2 -v",
+			host:    "localhost",
+			port:    8081,
+			regions: []string{"us-west-1", "us-west-2"},
+			verbose: true,
+			args:    []string{"-p", "8081", "-v", "-r", "us-west-1,us-west-2"},
 		},
 		{
-			name:     "--port 8081 --regions us-west-1,us-west-2 --profiles prod,dev",
+			name:     "--port 8081 --regions us-west-1,us-west-2 --profiles prod,dev --role-arns arn1,arn2",
 			host:     "localhost",
 			port:     8081,
 			regions:  []string{"us-west-1", "us-west-2"},
 			profiles: []string{"prod", "dev"},
-			verbose:  false,
-			args:     []string{"--port", "8081", "--regions", "us-west-1,us-west-2", "--profiles", "prod,dev"},
+			roles:    []string{"arn1", "arn2"},
+			args:     []string{"--port", "8081", "--regions", "us-west-1,us-west-2", "--profiles", "prod,dev", "--role-arns", "arn1,arn2"},
 		},
 		{
 			name:     "-r us-west-1 -r us-west-2 --profile dev --profile prod",
@@ -67,26 +63,19 @@ func TestRootCommand(t *testing.T) {
 			port:     8080,
 			regions:  []string{"us-west-1", "us-west-2"},
 			profiles: []string{"dev", "prod"},
-			verbose:  false,
 			args:     []string{"-r", "us-west-1", "-r", "us-west-2", "--profiles", "dev", "--profiles", "prod"},
 		},
 		{
-			name:     "-c ../pkg/config/test/custom-host-port.yaml",
-			host:     "helloworld",
-			port:     8082,
-			regions:  []string(nil),
-			profiles: []string(nil),
-			verbose:  false,
-			args:     []string{"-c", "../pkg/config/test/custom-host-port.yaml"},
+			name: "-c ../pkg/config/test/custom-host-port.yaml",
+			host: "helloworld",
+			port: 8082,
+			args: []string{"-c", "../pkg/config/test/custom-host-port.yaml"},
 		},
 		{
-			name:     "--port 8081 --config ../pkg/config/test/custom-host-port.yaml",
-			host:     "helloworld",
-			port:     8081,
-			regions:  []string(nil),
-			profiles: []string(nil),
-			verbose:  false,
-			args:     []string{"--port", "8081", "--config", "../pkg/config/test/custom-host-port.yaml"},
+			name: "--port 8081 --config ../pkg/config/test/custom-host-port.yaml",
+			host: "helloworld",
+			port: 8081,
+			args: []string{"--port", "8081", "--config", "../pkg/config/test/custom-host-port.yaml"},
 		},
 	}
 
@@ -99,6 +88,7 @@ func TestRootCommand(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.regions, actualConfig.Regions)
 			require.Equal(t, tc.profiles, actualConfig.Profiles)
+			require.Equal(t, tc.roles, actualConfig.RoleArns)
 			require.Equal(t, tc.host, actualConfig.Web.Host)
 			require.Equal(t, tc.port, actualConfig.Web.Port)
 			require.True(t, tc.verbose == actualLogger.Core().Enabled(zap.DebugLevel))

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.12.0 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.0
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.12 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.6 // indirect

--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -39,3 +39,7 @@ providers:
 
     # use a specific AWS profile
     # profile: dev-AKIAXXXXXXXXXXXXXX
+
+    # use a specific AWS role
+    # roleArn: arn:aws:iam::123456789012:role/ReadOnlyAcces
+

--- a/pkg/config/test/use-role-config.yaml
+++ b/pkg/config/test/use-role-config.yaml
@@ -1,0 +1,5 @@
+providers:
+  - cloud: aws
+    roleArn: my-profile
+    regions: 
+      - arn:aws:iam::1234567890:role/EC2Read

--- a/pkg/provider/aws/sts.go
+++ b/pkg/provider/aws/sts.go
@@ -1,0 +1,30 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+//assumeRoleCredentials will assume the role and returns the credentials to use
+func assumeRoleCredentials(config aws.Config, roleArn string) (aws.Credentials, error) {
+	//generate a unique session name
+	sessionName := fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+	response, err := sts.NewFromConfig(config).AssumeRole(context.TODO(), &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String(sessionName),
+	})
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+	return aws.Credentials{
+		AccessKeyID:     *response.Credentials.AccessKeyId,
+		SecretAccessKey: *response.Credentials.SecretAccessKey,
+		SessionToken:    *response.Credentials.SessionToken,
+		CanExpire:       true,
+		Expires:         *response.Credentials.Expiration,
+	}, nil
+}


### PR DESCRIPTION
The user can set the option `--role-arns` to assume some AWS roles.
The config part is pretty much like `--profiles`.

The AWS change consists on assuming a role to get credentials and re-authenticating with these credentials: [code](https://github.com/run-x/cloudgrep/blob/6df7dd0313c4f574e78fc1e7b5e3146c1a036f4b/pkg/provider/aws/provider.go#L92-L107)

It was tested manually.
I didn't add an integration test for this, but I added a task in our backlog so we can do it later [CGREP-152](https://run-x.atlassian.net/browse/CGREP-152).