### PR TITLE
Deduplicate configuration of standard model.Resource fields

### DIFF
--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	cfg "github.com/run-x/cloudgrep/pkg/config"
+	"github.com/run-x/cloudgrep/pkg/model"
 	regionutil "github.com/run-x/cloudgrep/pkg/provider/aws/regions"
 	awsutil "github.com/run-x/cloudgrep/pkg/provider/aws/util"
 	"github.com/run-x/cloudgrep/pkg/provider/types"
@@ -52,23 +53,27 @@ func (p *Provider) converterFor(resourceType string) resourceconverter.ResourceC
 	}
 
 	region := p.region.ID()
+	factory := func() model.Resource {
+		return model.Resource{
+			AccountId: p.accountId,
+			Region:    region,
+			Type:      resourceType,
+		}
+	}
+
 	if mapping.UseMapConverter {
 		return &resourceconverter.MapConverter{
-			AccountId:      p.accountId,
-			Region:         region,
-			ResourceType:   resourceType,
-			TagField:       mapping.TagField,
-			IdField:        mapping.IdField,
-			DisplayIdField: mapping.DisplayIDField,
+			ResourceFactory: factory,
+			TagField:        mapping.TagField,
+			IdField:         mapping.IdField,
+			DisplayIdField:  mapping.DisplayIDField,
 		}
 	}
 	return &resourceconverter.ReflectionConverter{
-		AccountId:      p.accountId,
-		Region:         region,
-		ResourceType:   resourceType,
-		TagField:       mapping.TagField,
-		IdField:        mapping.IdField,
-		DisplayIdField: mapping.DisplayIDField,
+		ResourceFactory: factory,
+		TagField:        mapping.TagField,
+		IdField:         mapping.IdField,
+		DisplayIdField:  mapping.DisplayIDField,
 	}
 }
 

--- a/pkg/resourceconverter/map_converter_test.go
+++ b/pkg/resourceconverter/map_converter_test.go
@@ -23,8 +23,12 @@ func TestMapConverter(t *testing.T) {
 		rC := &MapConverter{
 			IdField:        "ID",
 			DisplayIdField: "Attr2",
-			ResourceType:   "DummyResource",
-			Region:         "dummyRegion",
+			ResourceFactory: func() model.Resource {
+				return model.Resource{
+					Type:   "DummyResource",
+					Region: "dummyRegion",
+				}
+			},
 		}
 		resource, err := rC.ToResource(ctx, entry, model.Tags{{Key: "key1", Value: "val3"}, {Key: "key2", Value: "val4"}})
 		require.NoError(t, err)

--- a/pkg/resourceconverter/resource_converter_test.go
+++ b/pkg/resourceconverter/resource_converter_test.go
@@ -25,6 +25,14 @@ type WeirdTags struct {
 
 func TestReflectionConverter(t *testing.T) {
 	ctx := context.Background()
+
+	factory := func() model.Resource {
+		return model.Resource{
+			Type:   "DummyResource",
+			Region: "dummyRegion",
+		}
+	}
+
 	t.Run("SimpleConversion", func(t *testing.T) {
 		entry := TestEntry{
 			ID:        "id1",
@@ -34,11 +42,10 @@ func TestReflectionConverter(t *testing.T) {
 			WeirdTags: []WeirdTags{{WeirdKey: "key1", WeirdValue: "val1"}, {WeirdKey: "key2", WeirdValue: "val2"}},
 		}
 		rC := &ReflectionConverter{
-			IdField:        "ID",
-			DisplayIdField: "Attr2",
-			TagField:       TagField{Name: "WeirdTags", Key: "WeirdKey", Value: "WeirdValue"},
-			ResourceType:   "DummyResource",
-			Region:         "dummyRegion",
+			IdField:         "ID",
+			DisplayIdField:  "Attr2",
+			TagField:        TagField{Name: "WeirdTags", Key: "WeirdKey", Value: "WeirdValue"},
+			ResourceFactory: factory,
 		}
 		resource, err := rC.ToResource(ctx, entry, nil)
 		require.NoError(t, err)
@@ -62,9 +69,8 @@ func TestReflectionConverter(t *testing.T) {
 			WeirdTags: []WeirdTags{{WeirdKey: "key1", WeirdValue: "val1"}, {WeirdKey: "key2", WeirdValue: "val2"}},
 		}
 		rC := &ReflectionConverter{
-			IdField:      "ID",
-			ResourceType: "DummyResource",
-			Region:       "dummyRegion",
+			IdField:         "ID",
+			ResourceFactory: factory,
 		}
 		resource, err := rC.ToResource(ctx, entry, model.Tags{{Key: "key1", Value: "val3"}, {Key: "key2", Value: "val4"}})
 		require.NoError(t, err)
@@ -87,10 +93,9 @@ func TestReflectionConverter(t *testing.T) {
 			WeirdTags: []WeirdTags{{WeirdKey: "key1", WeirdValue: "val1"}, {WeirdKey: "key2", WeirdValue: "val2"}},
 		}
 		rC := &ReflectionConverter{
-			IdField:      "ID",
-			ResourceType: "DummyResource",
-			Region:       "dummyRegion",
-			TagField:     TagField{Name: "WeirdTags2", Key: "WeirdKey", Value: "WeirdValue"},
+			IdField:         "ID",
+			ResourceFactory: factory,
+			TagField:        TagField{Name: "WeirdTags2", Key: "WeirdKey", Value: "WeirdValue"},
 		}
 		_, err := rC.ToResource(ctx, entry, nil)
 		require.ErrorContains(t, err, "could not find tag field 'WeirdTags2' for type 'DummyResource'")
@@ -105,9 +110,8 @@ func TestReflectionConverter(t *testing.T) {
 			WeirdTags: []WeirdTags{{WeirdKey: "key1", WeirdValue: "val1"}, {WeirdKey: "key2", WeirdValue: "val2"}},
 		}
 		rC := &ReflectionConverter{
-			IdField:      "ID2",
-			ResourceType: "DummyResource",
-			Region:       "dummyRegion",
+			IdField:         "ID2",
+			ResourceFactory: factory,
 		}
 		_, err := rC.ToResource(ctx, entry, model.Tags{{Key: "key1", Value: "val3"}, {Key: "key2", Value: "val4"}})
 		require.ErrorContains(t, err, "could not find id field 'ID2' for type 'DummyResource'")
@@ -122,10 +126,9 @@ func TestReflectionConverter(t *testing.T) {
 			WeirdTags: []WeirdTags{{WeirdKey: "key1", WeirdValue: "val1"}, {WeirdKey: "key2", WeirdValue: "val2"}},
 		}
 		rC := &ReflectionConverter{
-			IdField:        "ID",
-			DisplayIdField: "DispID",
-			ResourceType:   "DummyResource",
-			Region:         "dummyRegion",
+			IdField:         "ID",
+			DisplayIdField:  "DispID",
+			ResourceFactory: factory,
 		}
 		_, err := rC.ToResource(ctx, entry, model.Tags{{Key: "key1", Value: "val3"}, {Key: "key2", Value: "val4"}})
 		require.ErrorContains(t, err, "could not find display id field 'DispID' for type 'DummyResource'")


### PR DESCRIPTION
For both the resource converters, we were setting account ID, resource type, and region on them, but they were being passed straight through to the `model.Resource` value. This PR changes it so the provider instead sets a "factory" function that handles setting these universal fields. This should make it cleaner in the future when we add additional fields to the `model.Resource` struct.