### PR TITLE
Add generic mechanism to call Go func to calculate display ID

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,3 +3,6 @@
 run:
   go: '1.17'
   timeout: 5m
+linters:
+  disable:
+    - structcheck # This linter is abandoned, with the last update several years ago.

--- a/hack/awsgen/config/field_test.go
+++ b/hack/awsgen/config/field_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestField_Decoding_string(t *testing.T) {
@@ -13,7 +12,7 @@ func TestField_Decoding_string(t *testing.T) {
 	in := `foo`
 	expected := Field{Name: "foo"}
 
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -23,7 +22,7 @@ func TestField_Decoding_mapping(t *testing.T) {
 	in := `{name: foo, sliceType: string}`
 	expected := Field{Name: "foo", SliceType: "string"}
 
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -31,13 +30,13 @@ func TestField_Decoding_mapping(t *testing.T) {
 func TestField_Decoding_mappingInvalid(t *testing.T) {
 	in := `{name: foo, pointer: string}`
 
-	err := yaml.Unmarshal([]byte(in), &Field{})
+	err := yamlUnmarshal([]byte(in), &Field{})
 	assert.ErrorContains(t, err, "cannot unmarshal !!str `string` into bool")
 }
 
 func TestField_Decoding_sequence(t *testing.T) {
 	in := "- foo\n- bar"
-	err := yaml.Unmarshal([]byte(in), &Field{})
+	err := yamlUnmarshal([]byte(in), &Field{})
 	assert.ErrorContains(t, err, "unexpected node kind")
 }
 
@@ -46,7 +45,7 @@ func TestField_Decoding_noName(t *testing.T) {
 	in := `{sliceType: string}`
 	expected := Field{}
 
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.ErrorContains(t, err, "missing \"name\"")
 	assert.Equal(t, expected, actual)
 }
@@ -82,7 +81,7 @@ func TestNestedField_Decoding_string(t *testing.T) {
 	expected := NestedField{Field{Name: "foo"}}
 
 	var actual NestedField
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -90,7 +89,7 @@ func TestNestedField_Decoding_string(t *testing.T) {
 func TestNestedField_Decoding_map(t *testing.T) {
 	in := "name: foo"
 
-	err := yaml.Unmarshal([]byte(in), &NestedField{})
+	err := yamlUnmarshal([]byte(in), &NestedField{})
 	assert.ErrorContains(t, err, "unexpected node kind")
 }
 
@@ -102,7 +101,7 @@ func TestNestedField_Decoding_list(t *testing.T) {
 	}
 
 	var actual NestedField
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }

--- a/hack/awsgen/config/testdata/foo.yaml
+++ b/hack/awsgen/config/testdata/foo.yaml
@@ -10,7 +10,6 @@ types:
         name: LoadBalancerArn
         pointer: true
     getTagsApi:
-      type: LoadBalancer
       call: DescribeTags
       inputIDField:
         name: ResourceArns
@@ -24,3 +23,6 @@ types:
             sliceType: types.Tag
         key: Key
         value: Value
+    transformers:
+      - foo.Bar
+      - spam[%type]

--- a/hack/awsgen/config/transformer.go
+++ b/hack/awsgen/config/transformer.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const TransformerTypePlaceholder = "%type"
+
+var _ yaml.Unmarshaler = &Transformer{}
+
+func (t *Transformer) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.MappingNode {
+		return t.decodeMappingNode(value)
+	}
+	if value.Kind == yaml.ScalarNode {
+		return t.decodeScalarNode(value)
+	}
+
+	return &yaml.TypeError{Errors: []string{
+		"unexpected node kind",
+	}}
+}
+
+func (t *Transformer) decodeScalarNode(value *yaml.Node) error {
+	var expr string
+	err := value.Decode(&expr)
+	if err != nil {
+		return err
+	}
+
+	*t = Transformer{Expr: expr}
+	return nil
+}
+
+func (t *Transformer) decodeMappingNode(value *yaml.Node) error {
+	// This must match the type def of Transformer
+	// (but importantly, this type is not a yaml.Unmarshaler to avoid infinite recursion)
+	transformer := struct {
+		Name         string `yaml:"name"`
+		Expr         string `yaml:"expr"`
+		ForceGeneric bool   `yaml:"generic"`
+	}{}
+
+	err := value.Decode(&transformer)
+	if err != nil {
+		return err
+	}
+
+	if transformer.Expr == "" {
+		return &yaml.TypeError{Errors: []string{
+			"missing \"expr\"",
+		}}
+	}
+
+	*t = transformer
+	return nil
+}
+
+func (t Transformer) IsGeneric() bool {
+	return t.ForceGeneric || strings.Contains(t.Expr, TransformerTypePlaceholder)
+}
+
+func (t Transformer) Expression(genericType string) string {
+	if t.IsGeneric() {
+		return strings.ReplaceAll(t.Expr, TransformerTypePlaceholder, genericType)
+	}
+
+	return t.Expr
+}

--- a/hack/awsgen/config/transformer_test.go
+++ b/hack/awsgen/config/transformer_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
 func TestTransformer_Decoding_string(t *testing.T) {
@@ -12,7 +11,7 @@ func TestTransformer_Decoding_string(t *testing.T) {
 	in := `foo`
 	expected := Transformer{Expr: "foo"}
 
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -22,7 +21,7 @@ func TestTransformer_Decoding_mappingExprOnly(t *testing.T) {
 	in := `{expr: bar}`
 	expected := Transformer{Expr: "bar"}
 
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -32,7 +31,7 @@ func TestTransformer_Decoding_mapping(t *testing.T) {
 	in := `{name: foo, expr: bar}`
 	expected := Transformer{Name: "foo", Expr: "bar"}
 
-	err := yaml.Unmarshal([]byte(in), &actual)
+	err := yamlUnmarshal([]byte(in), &actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -40,6 +39,32 @@ func TestTransformer_Decoding_mapping(t *testing.T) {
 func TestTransformer_Decoding_mappingInvalid(t *testing.T) {
 	in := `{name: [1, 2], expr: bar}`
 
-	err := yaml.Unmarshal([]byte(in), &Field{})
+	err := yamlUnmarshal([]byte(in), &Transformer{})
 	assert.ErrorContains(t, err, "cannot unmarshal !!seq into string")
+}
+
+func TestTransformer_Decoding_mappingMissingExpr(t *testing.T) {
+	in := `{name: foo}`
+
+	err := yamlUnmarshal([]byte(in), &Transformer{})
+	assert.ErrorContains(t, err, "missing \"expr\"")
+}
+
+func TestTransformer_Decoding_invalidKind(t *testing.T) {
+	in := `[1]`
+
+	err := yamlUnmarshal([]byte(in), &Transformer{})
+	assert.ErrorContains(t, err, "unexpected node kind")
+}
+
+func TestTransformer_Expression_concrete(t *testing.T) {
+	tr := Transformer{Expr: "foo[Bar]"}
+
+	assert.Equal(t, "foo[Bar]", tr.Expression("Spam"))
+}
+
+func TestTransformer_Expression_generic(t *testing.T) {
+	tr := Transformer{Expr: "foo[%type]"}
+
+	assert.Equal(t, "foo[Spam]", tr.Expression("Spam"))
 }

--- a/hack/awsgen/config/transformer_test.go
+++ b/hack/awsgen/config/transformer_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestTransformer_Decoding_string(t *testing.T) {
+	var actual Transformer
+	in := `foo`
+	expected := Transformer{Expr: "foo"}
+
+	err := yaml.Unmarshal([]byte(in), &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTransformer_Decoding_mappingExprOnly(t *testing.T) {
+	var actual Transformer
+	in := `{expr: bar}`
+	expected := Transformer{Expr: "bar"}
+
+	err := yaml.Unmarshal([]byte(in), &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTransformer_Decoding_mapping(t *testing.T) {
+	var actual Transformer
+	in := `{name: foo, expr: bar}`
+	expected := Transformer{Name: "foo", Expr: "bar"}
+
+	err := yaml.Unmarshal([]byte(in), &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestTransformer_Decoding_mappingInvalid(t *testing.T) {
+	in := `{name: [1, 2], expr: bar}`
+
+	err := yaml.Unmarshal([]byte(in), &Field{})
+	assert.ErrorContains(t, err, "cannot unmarshal !!seq into string")
+}

--- a/hack/awsgen/config/types.go
+++ b/hack/awsgen/config/types.go
@@ -49,6 +49,9 @@ type Type struct {
 	// GetTagsAPI contains the configuration used for pulling the tags for each resource of this type.
 	// It is not required if the ListAPI is able to pull tags itself.
 	GetTagsAPI GetTagsAPI `yaml:"getTagsApi"`
+
+	// Transformers is the list of transformer functions to apply to resources before persisting them.
+	Transformers []Transformer `yaml:"transformers"`
 }
 
 // ListAPI is configuration for calling an AWS API to list resources of a type
@@ -67,6 +70,10 @@ type ListAPI struct {
 	// Pointer and SliceType are not yet supported in these fields.
 	OutputKey NestedField `yaml:"outputKey"`
 
+	// SDKType is the name of the struct type in the service's `types` package returned by the API.
+	// Defaults to `Type.Name`
+	SDKType string `yaml:"sdkType"`
+
 	// IDField points to the field within each resource struct that stores the ID of that resource
 	IDField Field `yaml:"id"`
 
@@ -81,10 +88,6 @@ type ListAPI struct {
 
 // GetTags is configuration for calling an AWS API to get the tags on a particular resource
 type GetTagsAPI struct {
-	// ResourceType is the name of the Go struct type within the services "types" package that represents this resource.
-	// This type must be what is returned by the list API.
-	ResourceType string `yaml:"type"`
-
 	// Call is the AWS API call to make within the service
 	Call string `yaml:"call"`
 
@@ -154,4 +157,21 @@ type InputOverrides struct {
 	// FullFuncs is a list functions to call with a pointer to the input struct.
 	// Each function must have a return type of an error.
 	FullFuncs []string `yaml:"fullFuncs"`
+}
+
+// Transformer refers to a transformer function that modifies the created resource in some way before it is persisted.
+// If specified as a plain string in YAML, it will be decoded with the string in the `Expr` field.
+type Transformer struct {
+	// Name is an optional identifier for this transformer, which will be used to add error information.
+	Name string `yaml:"name"`
+
+	// Expr is the Go expression that evaluates to a transformer function.
+	// If the expression needs to resolve the ListAPI.SDKType, it can use the special replacement string "%type",
+	// which will be replaced before validating the expression.
+	// If "%type" is not included and ForceGeneric is false, the expression must evalutate to a resourceconverter.TransformResourceFunc value.
+	// Otherwise, the expression must evaluate to a TransformFunc[%type]
+	Expr string `yaml:"expr"`
+
+	// ForceGeneric causes the Expr to be treated as resolving to a resourceconverter.TransformFunc[%type], regardless of the expression's contents.
+	ForceGeneric bool `yaml:"generic"`
 }

--- a/hack/awsgen/config/util_test.go
+++ b/hack/awsgen/config/util_test.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+func yamlUnmarshal(in []byte, out any) error {
+	r := bytes.NewReader(in)
+	d := yaml.NewDecoder(r)
+	d.KnownFields(true)
+
+	return d.Decode(out)
+}

--- a/hack/awsgen/config/validate_list_api.go
+++ b/hack/awsgen/config/validate_list_api.go
@@ -10,6 +10,7 @@ func (api ListAPI) Validate() []error {
 	errs = append(errs, validateFuncs(api,
 		validateListAPICall,
 		validateListAPIOutputKey,
+		validateListAPISDKType,
 		validateListAPIIDField,
 		validateListAPITagField,
 		validateListAPIInputOverrides,
@@ -24,6 +25,14 @@ func validateListAPICall(api ListAPI) []error {
 
 func validateListAPIOutputKey(api ListAPI) []error {
 	return api.OutputKey.ValidateSimple("outputKey")
+}
+
+func validateListAPISDKType(api ListAPI) []error {
+	if api.SDKType == "" {
+		return nil
+	}
+
+	return validateExportedIdentifier("sdkType", api.SDKType)
 }
 
 func validateListAPIIDField(api ListAPI) []error {

--- a/hack/awsgen/config/validate_list_api_test.go
+++ b/hack/awsgen/config/validate_list_api_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestListAPI_Validate_1(t *testing.T) {
 	api := ListAPI{
-		Call: "foo",
+		Call:    "foo",
+		SDKType: "foo",
 		Tags: &TagField{
 			Style: "struct",
 			Value: "bar",
@@ -17,6 +18,7 @@ func TestListAPI_Validate_1(t *testing.T) {
 	expected := []string{
 		"call is not a valid Go exported identifier: foo",
 		"outputKey cannot be empty",
+		"sdkType is not a valid Go exported identifier: foo",
 		"id: name required",
 		"tags: field cannot be empty",
 		"tags: key required with style=struct",

--- a/hack/awsgen/config/validate_tag_api.go
+++ b/hack/awsgen/config/validate_tag_api.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -11,7 +10,6 @@ func (api GetTagsAPI) Validate() []error {
 	if api.Has() {
 		errs = append(errs, validateFuncs(api,
 			validateTagAPICall,
-			validateTagAPIResourceType,
 			validateTagAPIInputIDField,
 			validateTagAPITags,
 			validateTagAPIAllowedAPIErrorCodes,
@@ -28,14 +26,6 @@ func (api GetTagsAPI) Validate() []error {
 
 func validateTagAPICall(api GetTagsAPI) []error {
 	return validateAPICall(api.Call)
-}
-
-func validateTagAPIResourceType(api GetTagsAPI) []error {
-	if api.ResourceType == "" {
-		return []error{errors.New("resourceType required")}
-	}
-
-	return validateExportedIdentifier("resourceType", api.ResourceType)
 }
 
 func validateTagAPIInputIDField(api GetTagsAPI) []error {
@@ -79,10 +69,6 @@ func validateTagAPIUnset(api GetTagsAPI) []error {
 
 	add := func(name string) {
 		errs = append(errs, fmt.Errorf(msgFmt, name))
-	}
-
-	if api.ResourceType != "" {
-		add("type")
 	}
 
 	if !api.InputIDField.Zero() {

--- a/hack/awsgen/config/validate_tag_api_test.go
+++ b/hack/awsgen/config/validate_tag_api_test.go
@@ -8,12 +8,10 @@ import (
 
 func TestGetTagsAPI_Validate_unset(t *testing.T) {
 	api := GetTagsAPI{
-		ResourceType:         "foo",
 		InputIDField:         Field{Name: "bar"},
 		AllowedAPIErrorCodes: []string{"spam"},
 	}
 	expected := []string{
-		"expected `call` to be set when type is set",
 		"expected `call` to be set when inputIDField is set",
 		"expected `call` to be set when allowedApiErrorCodes is set",
 	}

--- a/hack/awsgen/config/validate_transfomer.go
+++ b/hack/awsgen/config/validate_transfomer.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"errors"
+	"strings"
+)
+
+func (t Transformer) Validate() []error {
+	var errs []error
+
+	errs = append(errs, validateFuncs(t,
+		validateTransformerExpression,
+	)...)
+
+	return errs
+}
+
+func validateTransformerExpression(t Transformer) []error {
+	expr := t.Expr
+	expr = strings.TrimSpace(expr)
+
+	if expr == "" {
+		return []error{
+			errors.New("expr is required"),
+		}
+	}
+
+	if t.IsGeneric() {
+		expr = strings.ReplaceAll(expr, TransformerTypePlaceholder, "types.T")
+	}
+
+	if !isValidGoExpression(expr) {
+		return []error{
+			errors.New("not a valid Go expression"),
+		}
+	}
+
+	return nil
+}

--- a/hack/awsgen/config/validate_transformer_test.go
+++ b/hack/awsgen/config/validate_transformer_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformer_Validate(t *testing.T) {
+	type test struct {
+		expr  string
+		valid bool
+	}
+	good := func(e string) test {
+		return test{expr: e, valid: true}
+	}
+	bad := func(e string) test {
+		return test{expr: e, valid: false}
+	}
+	tests := []test{
+		good("foo"),
+		bad("1, 2"),
+		good("generic[%type]"),
+		bad("generic[%type]."),
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.expr, func(t *testing.T) {
+			transformer := Transformer{Expr: testCase.expr}
+			errs := transformer.Validate()
+			errStrs := errorsToStrings(errs)
+
+			var expected []string
+
+			if !testCase.valid {
+				expected = []string{
+					"not a valid Go expression",
+				}
+			}
+			assert.ElementsMatch(t, expected, errStrs)
+		})
+	}
+}

--- a/hack/awsgen/config/validate_type_test.go
+++ b/hack/awsgen/config/validate_type_test.go
@@ -42,6 +42,48 @@ func TestType_Validate_missingGetTagsApiTags(t *testing.T) {
 	assert.ElementsMatch(t, expected, errStrs)
 }
 
+func TestType_Validate_transformersInvalid(t *testing.T) {
+	typ := Type{
+		Name:    "Foo",
+		ListAPI: ListAPI{Tags: &TagField{}},
+		Transformers: []Transformer{
+			{
+				Name: "bar",
+				Expr: ".",
+			},
+			{
+				Name: "2",
+				Expr: "",
+			},
+			{
+				Name: "spam",
+				Expr: "%type",
+			},
+			{
+				Name: "bar",
+				Expr: "",
+			},
+			{
+				Name: "",
+				Expr: "!",
+			},
+		},
+	}
+
+	expected := []string{
+		"type 'Foo': transformers[bar]: not a valid Go expression",
+		"type 'Foo': transformers[1]: name cannot be an int",
+		"type 'Foo': transformers[3]: name is duplicated: bar",
+		"type 'Foo': transformers[3]: expr is required",
+		"type 'Foo': transformers[4]: not a valid Go expression",
+	}
+
+	errs := typ.Validate()
+	errStrs := typeValidateRemoveApiErrors(typ, errs)
+
+	assert.ElementsMatch(t, expected, errStrs)
+}
+
 func typeValidateRemoveApiErrors(typ Type, errs []error) []string {
 	subErrs := typ.subValidate()
 	setErrContextType(typ, subErrs)

--- a/hack/awsgen/config/validate_util.go
+++ b/hack/awsgen/config/validate_util.go
@@ -1,12 +1,18 @@
 package config
 
 import (
+	"go/parser"
 	"go/token"
 	"strings"
 )
 
 func isValidExportedIdentifier(id string) bool {
 	return token.IsIdentifier(id) && token.IsExported(id)
+}
+
+func isValidGoExpression(expr string) bool {
+	_, err := parser.ParseExpr(expr)
+	return err == nil
 }
 
 func isValidTypeRef(typ string) bool {

--- a/hack/awsgen/generator/generator_test.go
+++ b/hack/awsgen/generator/generator_test.go
@@ -30,14 +30,14 @@ func TestGenerator(t *testing.T) {
 							},
 							Pagination: true,
 							OutputKey:  config.NestedField{config.Field{Name: "Spam"}, config.Field{Name: "Ham"}},
+							SDKType:    "Foo",
 							IDField: config.Field{
 								Name:    "ID",
 								Pointer: true,
 							},
 						},
 						GetTagsAPI: config.GetTagsAPI{
-							ResourceType: "BarValue",
-							Call:         "GetBarTags",
+							Call: "GetBarTags",
 							InputIDField: config.Field{
 								Name:      "BarID",
 								SliceType: "types.BarIDType",
@@ -53,6 +53,22 @@ func TestGenerator(t *testing.T) {
 							},
 							AllowedAPIErrorCodes: []string{
 								"SpamError",
+							},
+						},
+						Transformers: []config.Transformer{
+							{
+								Name: "foo",
+								Expr: "bar",
+							},
+							{
+								Name: "spam",
+								Expr: "ham[%type]",
+							},
+							{
+								Expr: "a",
+							},
+							{
+								Expr: "b[%type]",
 							},
 						},
 					},

--- a/hack/awsgen/generator/util.go
+++ b/hack/awsgen/generator/util.go
@@ -96,3 +96,11 @@ func lowerCamelCaseJoin(parts ...string) string {
 
 	return strings.Join(out, "")
 }
+
+func sdkType(typ config.Type) string {
+	if typ.ListAPI.SDKType != "" {
+		return typ.ListAPI.SDKType
+	}
+
+	return typ.Name
+}

--- a/hack/awsgen/template/templates/list.go.tmpl
+++ b/hack/awsgen/template/templates/list.go.tmpl
@@ -6,7 +6,7 @@ if err != nil {
 
 {{- define "output" }}
 {{- if .IsLast }}
-if err := resourceconverter.{{ .Data.ConvertCall }}(ctx, output, resourceConverter, {{ .IterVar }}.{{ .Current.Name }} {{- .Data.ConvertTail }}); err != nil {
+if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, {{ .IterVar }}.{{ .Current.Name }} {{- .Data.ConvertTail }}); err != nil {
 	return err
 }
 {{- else }}
@@ -35,15 +35,25 @@ func (p *{{ .ProviderName}}) {{ .FuncName }}(ctx context.Context, output chan<- 
 
 	resourceConverter := p.converterFor({{ .ResourceName | quote }})
 
-	{{- $convertCall := "SendAllConverted" }}
 	{{- $convertTail := "" }}
 
-	{{- if .TagFuncName }}
-		{{- $convertCall = "SendAllConvertedTags" }}
-		{{- $convertTail = (cat ", p." .TagFuncName) }}
+	{{- if .Transformers }}
+	var transformers resourceconverter.Transformers[{{ .SDKType }}]
+	{{- range .Transformers }}
+	{{- if and .Name .IsGeneric }}
+	transformers.AddNamed({{ .Name | quote }}, {{ .Expression $.SDKType }})
+	{{- else if .Name }}
+	transformers.AddNamedResource({{ .Name | quote }}, {{ .Expression $.SDKType }})
+	{{- else if .IsGeneric }}
+	transformers.Add({{ .Expression $.SDKType }})
+	{{- else }}
+	transformers.AddResource({{ .Expression $.SDKType }})
+	{{- end }}
 	{{- end }}
 
-	{{- quiet (.OutputKey.SetData "ConvertCall" $convertCall) }}
+	{{- $convertTail = ", transformers" }}
+	{{- end }}
+
 	{{- quiet (.OutputKey.SetData "ConvertTail" $convertTail) }}
 
 	{{- if .Paginated }}

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -19,6 +19,16 @@ type Resource struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 }
 
+// EffectiveDisplayId returns the ID displayed to the user,
+// which is the DisplayId if set, else the Id
+func (r Resource) EffectiveDisplayId() string {
+	if r.DisplayId != "" {
+		return r.DisplayId
+	}
+
+	return r.Id
+}
+
 type Resources []*Resource
 type ResourcesResponse struct {
 	Count       int         `json:"count"`

--- a/pkg/model/resource_test.go
+++ b/pkg/model/resource_test.go
@@ -39,3 +39,15 @@ func TestClean(t *testing.T) {
 	assert.False(t, r1.UpdatedAt.IsZero())
 	assert.True(t, rs.Clean()[0].UpdatedAt.IsZero())
 }
+
+func TestResource_EffectiveDisplayId(t *testing.T) {
+	r1 := Resource{
+		Id: "foo", DisplayId: "bar",
+	}
+	r2 := Resource{
+		Id: "foo",
+	}
+
+	assert.Equal(t, "bar", r1.EffectiveDisplayId())
+	assert.Equal(t, "foo", r2.EffectiveDisplayId())
+}

--- a/pkg/provider/aws/cloudfront.go
+++ b/pkg/provider/aws/cloudfront.go
@@ -34,7 +34,10 @@ func (p *Provider) fetch_cloudfront_Distribution(ctx context.Context, output cha
 		distributions = append(distributions, page.DistributionList.Items...)
 	}
 
-	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, distributions, p.getTags_cloudfront_Distribution); err != nil {
+	var transformers resourceconverter.Transformers[types.DistributionSummary]
+	transformers.AddTags(p.getTags_cloudfront_Distribution)
+
+	if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, distributions, transformers); err != nil {
 		return err
 	}
 

--- a/pkg/provider/aws/config/elasticache.yaml
+++ b/pkg/provider/aws/config/elasticache.yaml
@@ -6,7 +6,6 @@ types:
       id: ARN
       pagination: true
     getTagsApi:
-      type: CacheCluster
       call: ListTagsForResource
       inputIDField:
         name: ResourceName

--- a/pkg/provider/aws/config/elb.yaml
+++ b/pkg/provider/aws/config/elb.yaml
@@ -11,7 +11,6 @@ types:
         name: LoadBalancerArn
         pointer: true
     getTagsApi:
-      type: LoadBalancer
       call: DescribeTags
       inputIDField:
         name: ResourceArns

--- a/pkg/provider/aws/config/iam.yaml
+++ b/pkg/provider/aws/config/iam.yaml
@@ -5,10 +5,10 @@ types:
     listApi:
       call: ListOpenIDConnectProviders
       outputKey: OpenIDConnectProviderList
+      sdkType: OpenIDConnectProviderListEntry
       id: Arn
     getTagsApi:
       call: ListOpenIDConnectProviderTags
-      type: OpenIDConnectProviderListEntry
       inputIDField: OpenIDConnectProviderArn
       tags: &tags
         style: struct
@@ -27,7 +27,6 @@ types:
       id: Arn
       displayId: PolicyName
     getTagsApi:
-      type: Policy
       call: ListPolicyTags
       inputIDField: PolicyArn
       tags: *tags
@@ -35,10 +34,10 @@ types:
     listApi:
       call: ListSAMLProviders
       outputKey: SAMLProviderList
+      sdkType: SAMLProviderListEntry
       id: Arn
     getTagsApi:
       call: ListSAMLProviderTags
-      type: SAMLProviderListEntry
       inputIDField: SAMLProviderArn
       tags: *tags
   - name: VirtualMFADevice
@@ -48,7 +47,6 @@ types:
       outputKey: VirtualMFADevices
       id: SerialNumber
     getTagsApi:
-      type: VirtualMFADevice
       call: ListMFADeviceTags
       inputIDField: SerialNumber
       tags: *tags

--- a/pkg/provider/aws/config/lambda.yaml
+++ b/pkg/provider/aws/config/lambda.yaml
@@ -4,11 +4,13 @@ types:
       call: ListFunctions
       pagination: true
       outputKey: Functions
+      sdkType: FunctionConfiguration
       id: FunctionArn
     getTagsApi:
-      type: FunctionConfiguration
       call: GetFunction
       inputIDField: FunctionName
       tags:
         style: map
         field: Tags
+    transformers:
+      - displayIdArnPrefix("function:")

--- a/pkg/provider/aws/config/route53.yaml
+++ b/pkg/provider/aws/config/route53.yaml
@@ -11,7 +11,6 @@ types:
         pointer: true
     getTagsApi:
       call: ListTagsForResources
-      type: HealthCheck
       inputIDField:
         name: ResourceIds
         sliceType: string
@@ -38,7 +37,6 @@ types:
       displayId: Name
     getTagsApi:
       call: ListTagsForResources
-      type: HostedZone
       inputIDField:
         name: ResourceIds
         sliceType: string

--- a/pkg/provider/aws/config/sns.yaml
+++ b/pkg/provider/aws/config/sns.yaml
@@ -4,9 +4,9 @@ types:
       call: ListTopics
       outputKey: Topics
       id: TopicArn
+      sdkType: Topic
       pagination: true
     getTagsApi:
-      type: Topic
       call: ListTagsForResource
       inputIDField: ResourceArn
       tags:

--- a/pkg/provider/aws/iam.go
+++ b/pkg/provider/aws/iam.go
@@ -39,6 +39,9 @@ func (p *Provider) fetch_iam_InstanceProfile(ctx context.Context, output chan<- 
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListInstanceProfilesInput{}
 
+	var transformers resourceconverter.Transformers[types.InstanceProfile]
+	transformers.AddTags(p.getTags_iam_InstanceProfile)
+
 	resourceConverter := p.converterFor("iam.InstanceProfile")
 	paginator := iam.NewListInstanceProfilesPaginator(client, input)
 	for paginator.HasMorePages() {
@@ -48,7 +51,7 @@ func (p *Provider) fetch_iam_InstanceProfile(ctx context.Context, output chan<- 
 			return fmt.Errorf("failed to fetch %s: %w", "iam.InstanceProfile", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.InstanceProfiles, p.getTags_iam_InstanceProfile); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.InstanceProfiles, transformers); err != nil {
 			return err
 		}
 	}
@@ -84,6 +87,9 @@ func (p *Provider) fetch_iam_Role(ctx context.Context, output chan<- model.Resou
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListRolesInput{}
 
+	var transformers resourceconverter.Transformers[types.Role]
+	transformers.AddTags(p.getTags_iam_Role)
+
 	resourceConverter := p.converterFor("iam.Role")
 	paginator := iam.NewListRolesPaginator(client, input)
 	for paginator.HasMorePages() {
@@ -93,7 +99,7 @@ func (p *Provider) fetch_iam_Role(ctx context.Context, output chan<- model.Resou
 			return fmt.Errorf("failed to fetch %s: %w", "iam.Role", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Roles, p.getTags_iam_Role); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.Roles, transformers); err != nil {
 			return err
 		}
 	}
@@ -129,6 +135,9 @@ func (p *Provider) fetch_iam_User(ctx context.Context, output chan<- model.Resou
 	client := iam.NewFromConfig(p.config)
 	input := &iam.ListUsersInput{}
 
+	var transformers resourceconverter.Transformers[types.User]
+	transformers.AddTags(p.getTags_iam_User)
+
 	resourceConverter := p.converterFor("iam.User")
 	paginator := iam.NewListUsersPaginator(client, input)
 	for paginator.HasMorePages() {
@@ -138,7 +147,7 @@ func (p *Provider) fetch_iam_User(ctx context.Context, output chan<- model.Resou
 			return fmt.Errorf("failed to fetch %s: %w", "iam.User", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Users, p.getTags_iam_User); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.Users, transformers); err != nil {
 			return err
 		}
 	}

--- a/pkg/provider/aws/iam_test.go
+++ b/pkg/provider/aws/iam_test.go
@@ -67,8 +67,9 @@ func TestFetchPolicies(t *testing.T) {
 	resources := testprovider.FetchResources(ctx.ctx, t, ctx.p, "iam.Policy")
 
 	testingutil.AssertResourceFilteredCount(t, resources, 1, testingutil.ResourceFilter{
-		Type:   "iam.Policy",
-		Region: globalRegion,
+		Type:            "iam.Policy",
+		Region:          globalRegion,
+		DisplayIdPrefix: "test-0-",
 		Tags: model.Tags{
 			{
 				Key:   testingutil.TestTag,

--- a/pkg/provider/aws/lambda_test.go
+++ b/pkg/provider/aws/lambda_test.go
@@ -17,8 +17,9 @@ func TestFetchFunctions(t *testing.T) {
 
 	testingutil.AssertResourceCount(t, resources, "", 2)
 	testingutil.AssertResourceFilteredCount(t, resources, 1, testingutil.ResourceFilter{
-		Type:   "lambda.Function",
-		Region: defaultRegion,
+		Type:            "lambda.Function",
+		Region:          defaultRegion,
+		DisplayIdPrefix: "testing-",
 		Tags: model.Tags{
 			{
 				Key:   testingutil.TestTag,

--- a/pkg/provider/aws/route53_test.go
+++ b/pkg/provider/aws/route53_test.go
@@ -35,8 +35,9 @@ func TestFetchHostedZones(t *testing.T) {
 	resources := testprovider.FetchResources(ctx.ctx, t, ctx.p, "route53.HostedZone")
 
 	testingutil.AssertResourceFilteredCount(t, resources, 1, testingutil.ResourceFilter{
-		Type:   "route53.HostedZone",
-		Region: globalRegion,
+		Type:            "route53.HostedZone",
+		Region:          globalRegion,
+		DisplayIdPrefix: "0.example.",
 		Tags: model.Tags{
 			{
 				Key:   testingutil.TestTag,

--- a/pkg/provider/aws/sqs.go
+++ b/pkg/provider/aws/sqs.go
@@ -61,7 +61,12 @@ func (p *Provider) fetch_sqs_Queue(ctx context.Context, output chan<- model.Reso
 		getQueueAttributesResult.Attributes[SqsQueueIdentifier] = queueUrl
 		queuesAttributes = append(queuesAttributes, getQueueAttributesResult.Attributes)
 	}
-	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, queuesAttributes, p.getTags_sqs_Queue); err != nil {
+
+	var transformers resourceconverter.Transformers[map[string]string]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTags_sqs_Queue))
+	transformers.AddNamedResource("displayId", displayIdArn)
+
+	if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, queuesAttributes, transformers); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/provider/aws/sqs_test.go
+++ b/pkg/provider/aws/sqs_test.go
@@ -17,8 +17,9 @@ func TestFetchSqsQueue(t *testing.T) {
 
 	testingutil.AssertResourceCount(t, resources, "", 1)
 	testingutil.AssertResourceFilteredCount(t, resources, 1, testingutil.ResourceFilter{
-		Type:   "sqs.Queue",
-		Region: defaultRegion,
+		Type:            "sqs.Queue",
+		Region:          defaultRegion,
+		DisplayIdPrefix: "testing-",
 		Tags: model.Tags{
 			{
 				Key:   testingutil.TestTag,

--- a/pkg/provider/aws/util.go
+++ b/pkg/provider/aws/util.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+
+	"github.com/run-x/cloudgrep/pkg/model"
+	"github.com/run-x/cloudgrep/pkg/resourceconverter"
+)
+
+// displayIdArn modifies the resource's display ID to be the "resource" part of the ARN.
+// Errors if the effective display ID is not an ARN.
+func displayIdArn(ctx context.Context, resource *model.Resource) error {
+	displayId := resource.EffectiveDisplayId()
+
+	parsed, err := arn.Parse(displayId)
+	if err != nil {
+		return fmt.Errorf("effective display ID ('%s') is not a valid AWS ARN: %w", displayId, err)
+	}
+
+	resource.DisplayId = parsed.Resource
+	return nil
+}
+
+// displayIdArnPrefix returns a transform func to modify the resource's display ID to be the "resource" part of the ARN, and additionally
+// drop some specified prefix from the start of the new display ID.
+// Errors if the effective display ID is not an ARN or the specified prefix is not present.
+func displayIdArnPrefix(prefix string) resourceconverter.TransformResourceFunc {
+	return func(ctx context.Context, resource *model.Resource) error {
+		displayId := resource.EffectiveDisplayId()
+
+		parsed, err := arn.Parse(displayId)
+		if err != nil {
+			return fmt.Errorf("effective display ID ('%s') is not a valid AWS ARN: %w", displayId, err)
+		}
+
+		arnResource := parsed.Resource
+		if !strings.HasPrefix(arnResource, prefix) {
+			return fmt.Errorf("effective display ID ('%s') ARN is missing prefix: %s", displayId, prefix)
+		}
+
+		arnResource = strings.TrimPrefix(arnResource, prefix)
+
+		resource.DisplayId = arnResource
+		return nil
+	}
+}

--- a/pkg/provider/aws/zz_elasticache.go
+++ b/pkg/provider/aws/zz_elasticache.go
@@ -25,6 +25,8 @@ func (p *Provider) fetchElasticacheCacheCluster(ctx context.Context, output chan
 	input := &elasticache.DescribeCacheClustersInput{}
 
 	resourceConverter := p.converterFor("elasticache.CacheCluster")
+	var transformers resourceconverter.Transformers[types.CacheCluster]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsElasticacheCacheCluster))
 	paginator := elasticache.NewDescribeCacheClustersPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -33,7 +35,7 @@ func (p *Provider) fetchElasticacheCacheCluster(ctx context.Context, output chan
 			return fmt.Errorf("failed to fetch %s: %w", "elasticache.CacheCluster", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.CacheClusters, p.getTagsElasticacheCacheCluster); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.CacheClusters, transformers); err != nil {
 			return err
 		}
 	}

--- a/pkg/provider/aws/zz_iam.go
+++ b/pkg/provider/aws/zz_iam.go
@@ -44,11 +44,13 @@ func (p *Provider) fetchIamOpenIDConnectProvider(ctx context.Context, output cha
 	input := &iam.ListOpenIDConnectProvidersInput{}
 
 	resourceConverter := p.converterFor("iam.OpenIDConnectProvider")
+	var transformers resourceconverter.Transformers[types.OpenIDConnectProviderListEntry]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsIamOpenIDConnectProvider))
 	results, err := client.ListOpenIDConnectProviders(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to fetch %s: %w", "iam.OpenIDConnectProvider", err)
 	}
-	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, results.OpenIDConnectProviderList, p.getTagsIamOpenIDConnectProvider); err != nil {
+	if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, results.OpenIDConnectProviderList, transformers); err != nil {
 		return err
 	}
 
@@ -84,6 +86,8 @@ func (p *Provider) fetchIamPolicy(ctx context.Context, output chan<- model.Resou
 	input.Scope = listPoliciesScope()
 
 	resourceConverter := p.converterFor("iam.Policy")
+	var transformers resourceconverter.Transformers[types.Policy]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsIamPolicy))
 	paginator := iam.NewListPoliciesPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -92,7 +96,7 @@ func (p *Provider) fetchIamPolicy(ctx context.Context, output chan<- model.Resou
 			return fmt.Errorf("failed to fetch %s: %w", "iam.Policy", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Policies, p.getTagsIamPolicy); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.Policies, transformers); err != nil {
 			return err
 		}
 	}
@@ -128,11 +132,13 @@ func (p *Provider) fetchIamSAMLProvider(ctx context.Context, output chan<- model
 	input := &iam.ListSAMLProvidersInput{}
 
 	resourceConverter := p.converterFor("iam.SAMLProvider")
+	var transformers resourceconverter.Transformers[types.SAMLProviderListEntry]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsIamSAMLProvider))
 	results, err := client.ListSAMLProviders(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to fetch %s: %w", "iam.SAMLProvider", err)
 	}
-	if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, results.SAMLProviderList, p.getTagsIamSAMLProvider); err != nil {
+	if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, results.SAMLProviderList, transformers); err != nil {
 		return err
 	}
 
@@ -167,6 +173,8 @@ func (p *Provider) fetchIamVirtualMFADevice(ctx context.Context, output chan<- m
 	input := &iam.ListVirtualMFADevicesInput{}
 
 	resourceConverter := p.converterFor("iam.VirtualMFADevice")
+	var transformers resourceconverter.Transformers[types.VirtualMFADevice]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsIamVirtualMFADevice))
 	paginator := iam.NewListVirtualMFADevicesPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -175,7 +183,7 @@ func (p *Provider) fetchIamVirtualMFADevice(ctx context.Context, output chan<- m
 			return fmt.Errorf("failed to fetch %s: %w", "iam.VirtualMFADevice", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.VirtualMFADevices, p.getTagsIamVirtualMFADevice); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.VirtualMFADevices, transformers); err != nil {
 			return err
 		}
 	}

--- a/pkg/provider/aws/zz_route53.go
+++ b/pkg/provider/aws/zz_route53.go
@@ -32,6 +32,8 @@ func (p *Provider) fetchRoute53HealthCheck(ctx context.Context, output chan<- mo
 	input := &route53.ListHealthChecksInput{}
 
 	resourceConverter := p.converterFor("route53.HealthCheck")
+	var transformers resourceconverter.Transformers[types.HealthCheck]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsRoute53HealthCheck))
 	paginator := route53.NewListHealthChecksPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -40,7 +42,7 @@ func (p *Provider) fetchRoute53HealthCheck(ctx context.Context, output chan<- mo
 			return fmt.Errorf("failed to fetch %s: %w", "route53.HealthCheck", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.HealthChecks, p.getTagsRoute53HealthCheck); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.HealthChecks, transformers); err != nil {
 			return err
 		}
 	}
@@ -86,6 +88,8 @@ func (p *Provider) fetchRoute53HostedZone(ctx context.Context, output chan<- mod
 	input := &route53.ListHostedZonesInput{}
 
 	resourceConverter := p.converterFor("route53.HostedZone")
+	var transformers resourceconverter.Transformers[types.HostedZone]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsRoute53HostedZone))
 	paginator := route53.NewListHostedZonesPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -94,7 +98,7 @@ func (p *Provider) fetchRoute53HostedZone(ctx context.Context, output chan<- mod
 			return fmt.Errorf("failed to fetch %s: %w", "route53.HostedZone", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.HostedZones, p.getTagsRoute53HostedZone); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.HostedZones, transformers); err != nil {
 			return err
 		}
 	}

--- a/pkg/provider/aws/zz_sns.go
+++ b/pkg/provider/aws/zz_sns.go
@@ -25,6 +25,8 @@ func (p *Provider) fetchSnsTopic(ctx context.Context, output chan<- model.Resour
 	input := &sns.ListTopicsInput{}
 
 	resourceConverter := p.converterFor("sns.Topic")
+	var transformers resourceconverter.Transformers[types.Topic]
+	transformers.AddNamed("tags", resourceconverter.TagTransformer(p.getTagsSnsTopic))
 	paginator := sns.NewListTopicsPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -33,7 +35,7 @@ func (p *Provider) fetchSnsTopic(ctx context.Context, output chan<- model.Resour
 			return fmt.Errorf("failed to fetch %s: %w", "sns.Topic", err)
 		}
 
-		if err := resourceconverter.SendAllConvertedTags(ctx, output, resourceConverter, page.Topics, p.getTagsSnsTopic); err != nil {
+		if err := resourceconverter.SendAllConverted(ctx, output, resourceConverter, page.Topics, transformers); err != nil {
 			return err
 		}
 	}

--- a/pkg/resourceconverter/transformer.go
+++ b/pkg/resourceconverter/transformer.go
@@ -66,6 +66,11 @@ func (t *Transformers[T]) AddNamedResource(name string, f TransformResourceFunc)
 	t.AddNamed(name, genericFunc)
 }
 
+// AddTags is a convienience function to add a tag func as a transformer
+func (t *Transformers[T]) AddTags(f TagFunc[T]) {
+	t.AddNamed("tags", TagTransformer(f))
+}
+
 // Apply applies all transform funcs in order to the specified raw SDK value and model.Resource.
 func (t Transformers[T]) Apply(ctx context.Context, raw T, resource *model.Resource) error {
 	for _, entry := range t.entries {

--- a/pkg/resourceconverter/transformer.go
+++ b/pkg/resourceconverter/transformer.go
@@ -1,0 +1,96 @@
+package resourceconverter
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/run-x/cloudgrep/pkg/model"
+	"github.com/run-x/cloudgrep/pkg/util"
+)
+
+// TransformFunc is a function that receives a raw SDK value and uses it to mutate the passed model.Resource in some way.
+type TransformFunc[T any] func(context.Context, T, *model.Resource) error
+
+// TransformResourceFunc is a function that modifies a model.Resource in some way
+type TransformResourceFunc func(context.Context, *model.Resource) error
+
+// Transformers is a constructed sequence of TransformFunc and TransformResourceFunc to modify created model.Resources.
+type Transformers[T any] struct {
+	// *robots in disguise*
+	entries []transformerEntry[T]
+}
+
+type transformerEntry[T any] struct {
+	name string
+	f    TransformFunc[T]
+}
+
+// Add adds new TransformFuncs to the list, automatically assigning names to each.
+func (t *Transformers[T]) Add(funcs ...TransformFunc[T]) {
+	for _, f := range funcs {
+		entry := transformerEntry[T]{
+			name: strconv.Itoa(len(t.entries)),
+			f:    f,
+		}
+		t.entries = append(t.entries, entry)
+	}
+}
+
+// AddResource adds new TransformResourceFuncs to the list, automatically assigning names to each.
+func (t *Transformers[T]) AddResource(funcs ...TransformResourceFunc) {
+	for _, f := range funcs {
+		resourceFunc := f
+		genericFunc := func(ctx context.Context, _ T, res *model.Resource) error {
+			return resourceFunc(ctx, res)
+		}
+		t.Add(genericFunc)
+	}
+}
+
+// AddNamed adds the given TransformFunc to the list under the specified name.
+func (t *Transformers[T]) AddNamed(name string, f TransformFunc[T]) {
+	entry := transformerEntry[T]{
+		name: name,
+		f:    f,
+	}
+	t.entries = append(t.entries, entry)
+}
+
+// AddNamedResource adds the given TransformResourceFunc to the list under the specified name.
+func (t *Transformers[T]) AddNamedResource(name string, f TransformResourceFunc) {
+	genericFunc := func(ctx context.Context, _ T, res *model.Resource) error {
+		return f(ctx, res)
+	}
+
+	t.AddNamed(name, genericFunc)
+}
+
+// Apply applies all transform funcs in order to the specified raw SDK value and model.Resource.
+func (t Transformers[T]) Apply(ctx context.Context, raw T, resource *model.Resource) error {
+	for _, entry := range t.entries {
+		err := entry.f(ctx, raw, resource)
+		if err != nil {
+			err = fmt.Errorf("transformer[%s] failed to apply: %w", entry.name, err)
+			return util.AddStackTrace(err)
+		}
+	}
+
+	return nil
+}
+
+// TagFunc is a function that returns the tags for a given SDK value.
+type TagFunc[T any] func(context.Context, T) (model.Tags, error)
+
+// TagTransformer converts a TagFunc[T] into a TransformFunc[T]
+func TagTransformer[T any](f TagFunc[T]) TransformFunc[T] {
+	return func(ctx context.Context, raw T, resource *model.Resource) error {
+		tags, err := f(ctx, raw)
+		if err != nil {
+			return err
+		}
+
+		resource.Tags = append(resource.Tags, tags...)
+		return nil
+	}
+}

--- a/pkg/resourceconverter/util.go
+++ b/pkg/resourceconverter/util.go
@@ -74,26 +74,3 @@ func SendAllConverted[T any](ctx context.Context, output chan<- model.Resource, 
 
 	return util.SendAllFromSlice(ctx, output, converted)
 }
-
-// Deprecated: Use SendAllConverted with a Transformers value instead (using the TagTransformer helper method)
-func SendAllConvertedTags[T any](ctx context.Context, output chan<- model.Resource, converter ResourceConverter, resources []T, tF TagFunc[T]) error {
-	var converted []model.Resource
-
-	for _, raw := range resources {
-		tags, err := tF(ctx, raw)
-		if err != nil {
-			return err
-		}
-		if tags == nil {
-			tags = []model.Tag{}
-		}
-		resource, err := converter.ToResource(ctx, raw, tags)
-		if err != nil {
-			return err
-		}
-
-		converted = append(converted, resource)
-	}
-
-	return util.SendAllFromSlice(ctx, output, converted)
-}

--- a/pkg/testingutil/filter.go
+++ b/pkg/testingutil/filter.go
@@ -11,11 +11,12 @@ import (
 )
 
 type ResourceFilter struct {
-	AccountId string
-	Region    string
-	Type      string
-	Tags      model.Tags
-	RawData   map[string]any
+	AccountId       string
+	Region          string
+	Type            string
+	DisplayIdPrefix string
+	Tags            model.Tags
+	RawData         map[string]any
 }
 
 func (f ResourceFilter) String() string {
@@ -120,6 +121,12 @@ func (f ResourceFilter) matchers() []resourceFilterMatcher {
 			present:  p(f.Region != ""),
 			stringer: s("Region=%s", f.Region),
 			match:    func(r model.Resource) bool { return f.Region == r.Region },
+		},
+		{
+			name:     "DisplayIdPrefix",
+			present:  p(f.DisplayIdPrefix != ""),
+			stringer: s("DisplayIdPrefix=%s", f.DisplayIdPrefix),
+			match:    func(r model.Resource) bool { return strings.HasPrefix(r.EffectiveDisplayId(), f.DisplayIdPrefix) },
 		},
 		{
 			name:    "Tags",

--- a/pkg/testingutil/filter_test.go
+++ b/pkg/testingutil/filter_test.go
@@ -180,6 +180,67 @@ func TestResourceFilter_Matches(t *testing.T) {
 				RawData: []byte(`{"foo":"ham"}`),
 			},
 		},
+		{
+			name: "displayIdPrefixMatchNoDisplay",
+			want: true,
+			filter: ResourceFilter{
+				DisplayIdPrefix: "foo-",
+			},
+			resource: model.Resource{
+				Id: "foo-1",
+			},
+		},
+		{
+			name: "displayIdPrefixMismatchNoDisplay",
+			filter: ResourceFilter{
+				DisplayIdPrefix: "bar",
+			},
+			resource: model.Resource{
+				Id: "ba",
+			},
+		},
+		{
+			name: "displayIdPrefixMatch",
+			want: true,
+			filter: ResourceFilter{
+				DisplayIdPrefix: "foo-",
+			},
+			resource: model.Resource{
+				Id:        "bar-1",
+				DisplayId: "foo-2",
+			},
+		},
+		{
+			name: "displayIdPrefixMismatch",
+			filter: ResourceFilter{
+				DisplayIdPrefix: "bar",
+			},
+			resource: model.Resource{
+				Id:        "bar",
+				DisplayId: "foo-2",
+			},
+		},
+		{
+			name: "accountIdMatch",
+			want: true,
+			filter: ResourceFilter{
+				AccountId: "foo",
+			},
+			resource: model.Resource{
+				AccountId: "foo",
+				Id:        "spam",
+			},
+		},
+		{
+			name: "accountIdMismatch",
+			filter: ResourceFilter{
+				AccountId: "foo",
+			},
+			resource: model.Resource{
+				AccountId: "bar",
+				Id:        "spam",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -273,8 +334,10 @@ func TestResourceFilter_String(t *testing.T) {
 		{
 			name: "full",
 			filter: ResourceFilter{
-				Type:   "A",
-				Region: "B",
+				AccountId:       "TestAccount",
+				Type:            "A",
+				Region:          "B",
+				DisplayIdPrefix: "foo-",
 				Tags: model.Tags{
 					{
 						Key: "Foo",
@@ -289,7 +352,7 @@ func TestResourceFilter_String(t *testing.T) {
 					"fool":  "took",
 				},
 			},
-			want: "ResourceFilter{Type=A, Region=B, Tags[Foo], Tags[Spam]=ham, RawData={apple=1, fool=took}}",
+			want: "ResourceFilter{AccountId=TestAccount, Type=A, Region=B, DisplayIdPrefix=foo-, Tags[Foo], Tags[Spam]=ham, RawData={apple=1, fool=took}}",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
- Adds a generic "transformer" concept, which is a mechanism to mutate resources after they are created with the ResourceConverter. Transformers are applied in order, can optionally also receive the original SDK resource, and receive a pointer to the model.Resource, which they are permitted to mutate as desired.
- While the initial target use case for transformers is to support display IDs, the ultimate goal is for a generic mechanism that makes it easy to extend and customize behavior for building a complete `model.Resource`, with a future look towards console URLs, inter-resource links, and common ID formats. 
- Updates tag functions to flow through the transformer mechanism. This change was made to reduce the complexity in the `resourceconverter.SendAllConverted*` functions (which will later be reduced to a single function), and because the "get tags" functions are very close to the transformer paradigm.
- The `sqs.Queue` (manual implementation) and `lambda.Function` (code generated) resources were updated to use the new transformer mechanism to demonstrate the utility. A later PR will update many other resources to improve their display IDs.
- Previously, awsgen only needed to know the type returned by the AWS SDK's list API call if we were also making a call to a separate "get tags" API. With this change, however, we now need to know it anytime a transformer is used (including tag functions), which in the future, will probably be every time. In most cases the SDK type is the same as type name we use in cloudgrep, but occasionally it's not; therefore, we infer the SDK type automatically based on the resource type, but this can be overridden with the `listApi.sdkType` field in the awsgen config.