### PR TITLE
Document resources that we support but don't test for

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cloudgrep is an asset explorer for cloud resources. It shows everything that's b
 ### Why use Cloudgrep?
 Cloudgrep's goal is to help engineering teams ensure every resource follows consistent tagging schema. It helps identify missing tags, misspellings and unowned resources. Consistent tagging leads to better cost attribution and faster incident resolution.
 
-Additionally, Cloudgrep is a great tool to visualize all cloud resources in a single place - across regions, accounts and providers. 
+Additionally, Cloudgrep is a great tool to visualize all cloud resources in a single place - across regions, accounts and providers.
 
 Try it out by downloading the latest [release](https://github.com/run-x/cloudgrep/releases)! For any questions, feel free to join our [Slack workspace](https://join.slack.com/t/cloudgrep/shared_invite/zt-1bl7fewv4-_iwch50U_pP8S3YKBvyyQQ).
 
@@ -171,6 +171,10 @@ providers:
 - autoscaling.AutoScalingGroup
 - cloudfront.Distribution
 - ec2.Address
+- ec2.CapacityReservation *(untested)*
+- ec2.ClientVpnEndpoint *(untested)*
+- ec2.Fleet *(untested)*
+- ec2.FlowLogs *(untested)*
 - ec2.Image
 - ec2.Instance
 - ec2.KeyPair
@@ -178,9 +182,11 @@ providers:
 - ec2.NatGateway
 - ec2.NetworkAcl
 - ec2.NetworkInterface
+- ec2.ReservedInstance *(untested)*
 - ec2.RouteTable
 - ec2.SecurityGroup
 - ec2.Snapshot
+- ec2.SpotInstanceRequest *(untested)*
 - ec2.Subnet
 - ec2.Volume
 - ec2.Vpc
@@ -192,6 +198,7 @@ providers:
 - iam.OpenIDConnectProvider
 - iam.Policy
 - iam.Role
+- iam.SAMLProvider *(untested)*
 - iam.User
 - iam.VirtualMFADevice
 - lambda.Function

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -38,7 +38,7 @@ Cloudgrep is an asset explorer for cloud resources. It shows everything that's b
 ### Why use Cloudgrep?
 Cloudgrep's goal is to help engineering teams ensure every resource follows consistent tagging schema. It helps identify missing tags, misspellings and unowned resources. Consistent tagging leads to better cost attribution and faster incident resolution.
 
-Additionally, Cloudgrep is a great tool to visualize all cloud resources in a single place - across regions, accounts and providers. 
+Additionally, Cloudgrep is a great tool to visualize all cloud resources in a single place - across regions, accounts and providers.
 
 Try it out by downloading the latest [release](https://github.com/run-x/cloudgrep/releases)! For any questions, feel free to join our [Slack workspace](https://join.slack.com/t/cloudgrep/shared_invite/zt-1bl7fewv4-_iwch50U_pP8S3YKBvyyQQ).
 
@@ -127,7 +127,7 @@ Here is the annotated config file, you only need to define this file if you wish
 
 # Supported resources
 {{range .supportedResources}}
-- {{. -}}
+- {{ .Type }}{{ if not .Tested }} *(untested)*{{ end -}}
 {{end}}
 
 # Development

--- a/pkg/provider/aws/registry.go
+++ b/pkg/provider/aws/registry.go
@@ -1,5 +1,10 @@
 package aws
 
+import (
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
 func (p *Provider) buildTypeMapping() map[string]mapper {
 	mapping := map[string]mapper{}
 
@@ -10,4 +15,13 @@ func (p *Provider) buildTypeMapping() map[string]mapper {
 	p.register_sqs(mapping)
 	p.register_iam_manual(mapping)
 	return mapping
+}
+
+// SupportedResources returns the resources that are supported by the AWS provider.
+func SupportedResources() []string {
+	p := Provider{}
+
+	resources := maps.Keys(p.buildTypeMapping())
+	slices.Sort(resources)
+	return resources
 }


### PR DESCRIPTION
We have some resources that we don't have integration tests for (generally because it would be difficult or expensive to maintain those resources in the test environments), but we still theoretically support. We should still document that we support them, since they may be helpful to the user.