### PR TITLE
Base Workflow with release and dispatch workflow permissions to deploy CloudGrep Demo on UI.

### DIFF
--- a/.github/workflows/cloudgrep-demo.yaml
+++ b/.github/workflows/cloudgrep-demo.yaml
@@ -1,0 +1,50 @@
+name: cloudgrep-demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      aws_key_id:
+        description: "AWS key ID"
+        required: true
+      aws_secret_key:
+        description: "AWS secret key"
+        required: true
+      aws_session_token:
+        description: "AWS session token"
+        required: true
+  release:
+    types: [ "published" ]
+
+env:
+  GO_VERSION: 1.18
+  CGO_ENABLED: 0
+
+  AWS_REGION: us-east-1
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  deploy-cloudgrep-demo:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_key_id }}
+      AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_secret_key }}
+      AWS_SESSION_TOKEN: ${{ github.event.inputs.aws_session_token }}
+      AWS_REGION: ${{ env.AWS_REGION }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: "Download Opta Binary"
+        run: /bin/bash -c "$(curl -fsSL https://docs.opta.dev/install.sh)"
+      - name: "Version Check"
+        run: $HOME/.opta/opta version
+      - name: "Build Cloudgrep demo Docker Image"
+        run: docker build . -f Dockerfile-demo -t cloudgrep:demo
+      - name: "Deploy Cloudgrep demo"
+        run: $HOME/.opta/opta deploy --env prod --image cloudgrep:demo

--- a/Dockerfile-demo
+++ b/Dockerfile-demo
@@ -1,0 +1,12 @@
+FROM golang:1.18-buster
+
+WORKDIR /app
+
+RUN apt-get update
+RUN apt-get install -y jq
+
+COPY demo.sh .
+
+EXPOSE 8080
+
+CMD [ "./demo.sh" ]

--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+TAG=$(curl https://api.github.com/repos/run-x/cloudgrep/releases/latest | jq -r .tag_name | sed 's/v//')
+echo "Tag: ${TAG}"
+
+DOWNLOAD_URL=https://github.com/run-x/cloudgrep/releases/download/v${TAG}/cloudgrep_${TAG}_linux_amd64.tar.gz
+echo "Download URL: ${DOWNLOAD_URL}"
+
+wget ${DOWNLOAD_URL}
+tar -xzf cloudgrep_${TAG}_linux_amd64.tar.gz
+
+chmod 777 cloudgrep
+./cloudgrep demo --bind=0.0.0.0

--- a/opta.yaml
+++ b/opta.yaml
@@ -1,0 +1,13 @@
+environments:
+  - name: staging
+    path: "git@github.com:run-x/runx-infra.git//staging/opta.yml?ref=main"
+  - name: prod
+    path: "git@github.com:run-x/runx-infra.git//production/opta.yml?ref=main"
+name: cloud-grep
+modules:
+  - type: k8s-service
+    name: app
+    port:
+      http: 8080
+    image: AUTO
+    public_uri: "cloudgrep.{parent.domain}"


### PR DESCRIPTION
This PR is to create a workflow to deploy CloudGrep Demo UI to https://cloudgrep.app.runx.dev so that users can play around with it.

Currently, the Demo is live on https://cloudgrep.staging.runx.dev/